### PR TITLE
Fix issues with device tree overlay generation for interrupt controller.

### DIFF
--- a/device_tree/data/common_proc.tcl
+++ b/device_tree/data/common_proc.tcl
@@ -1350,7 +1350,7 @@ proc write_dt args {
 		}
 	}
 	if {[string match -nocase $dt "pldt"] && $dt_overlay} {
-		puts $fd "\/dts-v1\/\n\/plugin\/;"
+		puts $fd "\/dts-v1\/;\n\/plugin\/;"
 	}
 	set dtcheck [string match -nocase $dt "pcwdt"]
 	if {$dtcheck != 1} {

--- a/intc/data/intc.tcl
+++ b/intc/data/intc.tcl
@@ -49,7 +49,7 @@
         add_prop $node "xlnx,kind-of-intr" $kind_of_intr hexint $dts_file 1
         if {$zocl} {
                 set num_intr_inputs "0x20"
-                set_drv_prop $drv_handle "xlnx,num-intr-inputs" $num_intr_inputs $node int
+                set_drv_prop $drv_handle "xlnx,num-intr-inputs" $num_intr_inputs int $node
         } else {
                 set_drv_conf_prop $drv_handle C_NUM_INTR_INPUTS "xlnx,num-intr-inputs" $node
         }


### PR DESCRIPTION
## 📋 Fix issues with device tree overlay generation for interrupt controller.

### 📌 Description

Fixed device tree overlay generation issues in the interrupt controller

- **Type of Change**: Bugfix

### 🚀 What Has Been Done?
- [x] In the file `common_proc.tcl` a semi-collon was mission in the device tree version marker 
- [x] In the in file `intc/data/intc.tcl` the argument order for the `set_drv_prop` function is not correct.

### 🧪 Testing 

I just executed the generation for the device tree I needed. I could not find the tests in this repo. If they exist I can run them.
