### PR TITLE
Fix issues with device tree overlay generation for interrupt controller.

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,25 +1,59 @@
-# System Device Tree Generator
+# System Device Tree Generator (SDTGen / DTG++)
 
-System Device Tree Generator aka DTG++. System device tree represents
-complete hw information in the form of device trees.
+A TCL package that can generate System Device Tree.
+More info on the evolution can be read in following segments.
 
-DTG++ uses tcls and HW HSI APIs in order to read the hardware
-information from XSA. The output dts represents all peripheral information
-and its properties, memories, clusters, soc peripheral information and soft
-IP information etc. It complies with system device tree specification.
+## Device Tree (DT)
+A device tree is a data structure and language for describing hardware. It is a description
+of hardware that is readable by an operating system so that the operating system doesn't
+need to hard code details of the machine.
+Info courtesy: https://www.kernel.org/doc/html/latest/devicetree/usage-model.html#linux-and-the-devicetree
 
-## Input
+## System Device Tree (SDT)
+The System Device Tree is a superset of a traditional Linux-compatible devicetree.
+An overview of System Device Tree concept can be found on the Linaro site [here](https://static.linaro.org/connect/lvc20/presentations/LVC20-314-0.pdf).
+System Device Tree is architected to be compatible with traditional device-tree files and acts as a superset extension of the original syntax.
+In general, System Device Tree represents the entirety of the system, including components not historically relevant to an operating system.
+Unlike regular Linux device tree which represents hardware information that is only needed for
+Linux/APU, System Device Tree represents complete hardware information in device tree format.
+For example, System Device Tree can carry information about the CPU cluster and memory associated with the Cortex-R CPU cluster in a device such as Zynq UltraScale+ MPSoC. While this information isn't needed for Linux to operate properly it can be used in the context of the Lopper tool (refer [link](https://static.linaro.org/connect/lvc20/presentations/LVC20-314-0.pdf)) to allow complex inter-software architectures to be specified in simple configuration files.
+More details on the System Device Tree spec can be found inside devicetree-org lopper repository [here](https://github.com/devicetree-org/lopper/tree/master/specification/source).
+
+## Hardware Software Interface (HSI)
+An AMD-Xilinx proprietary TCL based utility that can extract the hardware specific data from
+the XSA (Xilinx Support Archive) file into a human readable format. The extracted hardware
+meta-data can then be passed on to the software world.
+
+## XSCT
+XSCT (Xilinx Software Command-Line) is a tool that allows us to create complete Xilinx SDK
+workspaces using the batch mode, investigate the hardware and software, debug and run the
+project, all from the command line. It is capable of running TCL scripts. It is an ‘umbrella’
+tool that covers; HSI, XSDB, SDTGen, Bootgen, and the debugger. More info on how to use HSI
+from XSCT command line can be found from these sections at:
+[Extracting HW info using HSI from the XSCT command line](https://xilinx-wiki.atlassian.net/wiki/spaces/A/pages/18841693/HSI+debugging+and+optimization+techniques#HSIdebuggingandoptimizationtechniques-ExtractingHWinfousingHSIfromtheXSCTcommandline:) and [Internal HSI utilities](https://xilinx-wiki.atlassian.net/wiki/spaces/A/pages/18841693/HSI+debugging+and+optimization+techniques#HSIdebuggingandoptimizationtechniques-InternalHSIutilities:).
+More details on XSCT tool can be accessed at [UG-1208](https://usermanual.wiki/Document/ug1208xsctreferenceguide.1558655150/view).
+
+## SDTGen (DTG++)
+An XSCT package that uses TCL scripts and Hardware HSI APIs to read the hardware information
+from XSA and put it in System Device Tree (SDT) format. The TCL source files for this
+package is kept in present repository and the same can be found in the installed xsct tool. Let's call this path the SDT repo from here on. Sample SDT repo location inside Vitis install may look like /home/abc/Xilinx/Vitis/2024.1/data/system-device-tree-xlnx. By default, the package sources the device_tree.tcl file from
+&lt;SDT repo&gt;/device_tree/data/device_tree.tcl and exports the following three procs as sdtgen commands:
+* set_dt_param
+* get_dt_param
+* generate_sdt
+
+## Input for SDTGen
 
 Vivado generated XSA.
 
-## Output
+## Output of SDTGen
 System Device Tree files.
 ```bash
-The generated dts has the following files.
-	soc.dtsi:	which is static soc specific file.
-			Ex: versal.dtsi
+The generated system device tree contains following files.
+	soc.dtsi:	which is a static SOC specific file.
+			e.g.: versal.dtsi
 	pl.dtsi:	which contains Programmable Logic(soft IPs) information.
-	board.dtsi:	which is board file.
+	board.dtsi:	which is Board file.
 			Ex: versal-vck190-reva
 	clk.dtsi:	which is clock information.
 			Ex: versal-clk.dtsi
@@ -28,110 +62,180 @@ The generated dts has the following files.
 	pcw.dtsi:	which contains peripheral configuration wizard information
 			of the peripherals.
 ```
-## DTS generation
+##### Note: Clock files, SOC file, BOARD files are static files which resides inside the DTG++.
+
+## Steps to use SDTGen
 			
 ```bash
 XSCT Setup:
 -------------
-        Launch XSCT tool
-        linux# xsct
+        Get the path of XSCT binary from the installed Vitis tool
+        (say: /home/abc/Xilinx/Vitis/2024.1/bin/xsct)
 
-Once xsct launched, at xsct prompt enter sdtgen commands as hown below for
-generating system device tree.
-SDT Command:
+Put commands like below in a TCL file (say sdt.tcl)
 ------------
-	xsct% sdtgen set_dt_param -board_dts <board file> -dir <directory name>
-		-xsa <Vivado XSA file>
-	Ex:
-	xsct% sdtgen set_dt_param -board_dts versal-vck190-reva -dir sdt
-		-xsa design_1_wrapper.xsa
-	xsct% sdtgen generate_sdt
-	xsct% ls sdt/
+	set outdir [lindex $argv 1]
+	set xsa [lindex $argv 0]
+	exec rm -rf $outdir
+	sdtgen set_dt_param -xsa $xsa -dir $outdir -board_dts zcu102-rev1.0
+	sdtgen generate_sdt
+------------
+
+Run XSCT command like below to get the SDT directory
+------------
+<xsct binary path> sdt.tcl <Vivado generated xsa path> <sdt outdir where files will be generated>
+e.g.
+/home/abc/Xilinx/Vitis/2024.1/bin/xsct sdt.tcl design1_wrapper.xsa sdt_outdir
 ```
 
-## Optional command line arguments
-### Dt parameter setting:
-Setting the dt parameters individually instead of
-Single line command mentioned above DTS generation, it is useful if
-we want to change only one parameter.
+## Command line arguments available with SDTGen
+### set_dt_param
+Takes the user inputs to set the parameters needed for the system device tree generation.
+* Has two mandatory arguments:
+	* -xsa : sets the XSA path for which SDT has to be generated.
+	* -dir : sets the output directory where the SDT has to be generated.
+* Other available optional arguments are:
+	* Category 1: Arguments that help in including dtsi files into final SDT
+		* -board_dts :
+			* includes the static board specific DTSI file available at
+				<SDT repo>/device_tree/data/kernel_dtsi/2024.1/BOARD inside the final SDT
+			* Mostly useful for Linux use cases.
+		* -include_dts :
+			* includes a user defined custom dtsi file inside the final SDT
+			* useful in providing customized use case specific data which can not be generated by the SDTGen tool
+			* Can be a handy workaround when SDTGen tool is generating a wrong data, can be used to override the existing data in the final SDT
+	* Category 2: Arguments that can help in debugging issues while generating SDT (Useful for developers)
+		* -trace :
+			* enables traces of the procs called to generate the SDT
+			* gives the sequence of APIs called, helps in debugging which proc call actually failed
+		* -debug :
+			* enables the warning prints wherever mentioned in the TCL scripts
+			* Helpful in getting more info on what might go missing in the final SDT even though the SDT generation is successful.
+			* Less frequently used.
+* Usage:
 ```bash
-xsct% sdtgen set_dt_param -dir output_dts
+# Note that the Multiple parameter setting in one line is allowed for all the available arguments of set_dt_param.
+
+# Set the mandatory set_dt_param arguments.
+xsct% sdtgen set_dt_param -dir outdir
 xsct% sdtgen set_dt_param -xsa design_1_wrapper.xsa
-xsct% sdtgen set_dt_param -board_dts versal-vck190-reva
-```
 
-### Enabling the debug:
-The below command enables the debug, like warnings.
-The default debug option is disabled, so there won't be any warnings
-```bash
-xsct% sdtgen set_dt_param -debug enable
-```
+# Multiple options in a single command
+xsct% sdtgen set_dt_param -xsa system.xsa -dir sdt_outdir
 
-### Enabling the trace:
-The below command enables the tracing.
-i.e. The flow of tcl procs that are getting invoked during sdt generation
-The default trace option is disabled
-```bash
+# Sample optional arguments with set_dt_param
+
+# Category 1: Arguments that help in including dtsi files into final SDT
+
+# Include board specific dtsi file from <SDT repo>/device_tree/data/kernel_dtsi/2024.1/BOARD path
+# Below command copies the <SDT repo>/device_tree/data/kernel_dtsi/2024.1/BOARD/zcu102-rev1.0.dtsi file into SDT output directory and add include statement in system-top.dts
+xsct% sdtgen set_dt_param -board_dts zcu102-rev1.0
+
+# Include a user defined custom dtsi file inside the final SDT
+# Below command copies the custom.dtsi file into SDT output directory and add include statement in system-top.dts
+xsct% sdtgen -include_dts <path>/custom.dtsi
+
+# Category 2 : Arguments that can help in debugging issues while generating SDT (Useful for developers)
+
+# Enable the trace i.e. the flow of TCL procs that are getting invoked during SDT generation. The default trace option is "disable".
 xsct% sdtgen set_dt_param -trace enable
-```
- 
-### Checking the dt parameters:
-```bash
-xsct% sdtgen get_dt_param -board_dts
-versal-vck190-reva
-xsct% sdtgen get_dt_param -dir
-output_dts
-xsct% sdtgen get_dt_param -xsa
-design_1_wrapper.xsa
-```
 
-### Copy hw artifacts from xsa
-```bash
-Copy hardware artifacts from a given xsa to output directory.
-USAGE: sdtgen set_dt_param -dir <output directory path> -xsa <xsa file>
-       sdtgen copy_hw_files
-```
+# Enable the debug option to get warning prints. The default debug option is "disable".
+xsct% sdtgen set_dt_param -debug enable
 
-### Using external repo
-```bash
-Sometimes user may want to modify the system device tree repo locally and use that for testing, insuch scenarios user can specify local repo using -repo option at set_dt_param.
-Please note that though the -repo option works for most of the cases where change is not in the core file i.e device_tree/data/device_tree.tcl, it will not work if change that needs to tested is in this file.
-In such cases, please follow below steps.
-1. Copy scripts/ folder from Vitis installation directory to local directory(ex: /tmp/path/)
-2. Set MYVIVADO environment variable with this path (ex: #export MYVIVADO=/tmp/path/)
-3. Now open file at /tmp/path/scripts/xsct/sdtgen/sdtgen.tcl and update it to source your own local device_tree.tcl instead of sourcing device_tree.tcl in installation path.
-4. Launch xsct now and continue with testing.
-```
-
-### Command Help:
-```bash
+# Command Help
 xsct% sdtgen set_dt_param -help
-Usage: set/get_dt_param [OPTION]
-	-repo                  system device tree repo source
-	-xsa                   Vivado hw design file
-	-board_dts             board specific file
-	-mainline_kernel       mainline kernel version
-	-kernel_ver            kernel version
-	-dir                   Directory where the dt files will be
-	                       generated
-	-debug                 Enable DTG++ debug
-	-trace                 Enable DTG++ traces
+            Usage: set/get_dt_param \[OPTION\]
+            -xsa              Vivado hw design file
+            -board_dts        board specific file
+            -dir              Directory where the dt files will be generated
+            -include_dts      DTS file to be include into final device tree
+            -debug            Enable DTG++ debug
+            -trace            Enable DTG++ traces
+
+# Combining everything in one command
+xsct% sdtgen set_dt_param -xsa system.xsa -dir sdt_outdir -board_dts zcu102-rev1.0 -include_dts ./custom.dtsi -trace enable -debug enable
+```
+### get_dt_param
+Returns the values set for the given argument. Returns the default values if the argument is not set using the "sdtgen set_dt_param".
+Do mark the usage of -repo. Helpful in finding the path of the system device tree TCLs being used.
+* Usage:
+```bash
+# Unlike "sdtgen set_dt_param", "sdtgen get_dt_param" expects only one argument in one command.
+
 xsct% sdtgen get_dt_param -help
-Usage: set/get_dt_param [OPTION]
-	-repo                  system device tree repo source
-	-xsa                   Vivado hw design file
-	-board_dts             board specific file
-	-mainline_kernel       mainline kernel version
-	-kernel_ver            kernel version
-	-dir                   Directory where the dt files will be
-	                       generated
-	-debug                 Enable DTG++ debug
-	-trace                 Enable DTG++ traces
-``` 
-### Notes
-1. Support added for Versal and ZynqMP.
-2. Clock files, SOC file, BOARD files are static files which resides
-   inside the DTG++.
-3. DTG++ generates all peripherals and its properties except for the
-   peripherals of type BUS, MONITOR and interconnects, noc_nmu,
-   noc_nsu, zynq_ultra_ps, versal_cips, noc_nsw axis_ila and ila.
+            Usage: set/get_dt_param \[OPTION\]
+            -repo             system device tree repo source
+            -xsa              Vivado hw design file
+            -board_dts        board specific file
+            -dir              Directory where the dt files will be generated
+            -include_dts      DTS file to be include into final device tree
+            -debug            Enable DTG++ debug
+            -trace            Enable DTG++ traces
+
+
+xcst% sdtgen get_dt_param -board_dts
+zcu102-rev1.0
+xcst% sdtgen get_dt_param -dir
+sdt_outdir
+xsct% sdtgen get_dt_param -xsa
+system.xsa
+xsct% sdtgen get_dt_param -repo
+/home/abc/Xilinx/Vitis/2024.1/data/system-device-tree-xlnx
+```
+### generate_sdt
+Generates the system device tree with the set parameters.
+Usage:
+```bash
+sdtgen generate_sdt
+```
+
+### How to use custom system device tree repository path with SDTGen
+#### Usage of CUSTOM_SDT_REPO (New in 2024.1):
+ As mentioned in earlier section, by default the TCL source files for sdtgen package is residing in the installed xsct tool under &lt;Installed Vitis Path&gt;/2024.1/data/system-device-tree-xlnx. If user wants to use the local SDT repo instead of the installed one, CUSTOM_SDT_REPO variable has to be set in the environment.
+
+```bash
+# Say the local SDT repo is kept at /home/abc/local_sdt_repo/system-device-tree-xlnx
+# Set the environment variable CUSTOM_SDT_REPO to the above local path to use TCL sources from this local path.
+# In BASH, it can be done using export command.
+# e.g.
+export CUSTOM_SDT_REPO=/home/abc/local_sdt_repo/system-device-tree-xlnx
+
+# Use the same tcl as generated above (without any change) and call xsct command
+/home/abc/Xilinx/Vitis/2024.1/bin/xsct sdt.tcl design1_wrapper.xsa sdt_outdir
+
+# This will lead to prints like below while launching XSCT which ensures that these local tcls are being sourced
+# Info: Detected Custom SDT repo path at /home/abc/local_sdt_repo/system-device-tree-xlnx Verifying...
+# Successfully sourced custom SDT Repo path.
+```
+#### Old flow (adopted till 2023.2, deprecated in 2024.1):
+##### If there is NO change in the device_tree.tcl file:
+* Use -repo option with sdtgen set_dt_param command.
+* Usage:
+```bash
+sdtgen set_dt_param -xsa design1_wrapper.xsa -dir outdir -repo /home/abc/local_sdt_repo/system-device-tree-xlnx
+```
+
+##### If there is a change in device_tree.tcl file along with other files:
+* When the installed XSCT path is write protected:
+	* Copy scripts folder from Vitis installation directory (say: /home/abc/Xilinx/Vitis/2024.1/scripts) to another path (eg./tmp/path/)
+	* Set MYVIVADO variable to the copied XSCT scripts path (eg. export MYVIVADO=/tmp/path/)
+	* Update the sdt_path variable in sdtgen.tcl kept at the copied XSCT scripts path. sdtgen.tcl can be found inside /tmp/path/scripts/xsct/sdtgen/sdtgen.tcl
+* When the installed XSCT path is NOT write protected:
+	* Update the sdt_path variable in sdtgen.tcl kept at /home/abc/Xilinx/Vitis/2024.1/scripts/xsct/sdtgen/sdtgen.tcl with local SDT repo path.
+* Set the -repo option to the local SDT repo path in conjunction with above steps when other file changes are also involved in addition to device_tree.tcl changes
+* Usage:
+```bash
+# Copy the scripts folder into a local location
+mkdir /tmp/path
+cp -r /home/abc/Xilinx/Vitis/2024.1/scripts /tmp/path/
+
+# Set the MYVIVADO variable to the copied XSCT scipts path
+export MYVIVADO=/tmp/path
+
+# Open the /tmp/path/scripts/xsct/sdtgen/sdtgen.tcl file and update the sdt_path with the local SDT repo path
+# eg. set sdt_path $env(XILINX_VITIS) -> set sdt_path /home/abc/local_sdt_repo/system-device-tree-xlnx
+
+# If there are changes in files other than device_tree.tcl
+sdtgen set_dt_param -xsa design1_wrapper.xsa -dir outdir -repo /home/abc/local_sdt_repo/system-device-tree-xlnx
+```

--- a/ai_engine/data/ai_engine.tcl
+++ b/ai_engine/data/ai_engine.tcl
@@ -77,8 +77,8 @@
         add_prop "${node}" "xlnx,core-rows" $corerows noformating "pl.dtsi"
         append memrows "/bits/ 8 <$mem_rows_start $mem_rows_num>"
         add_prop "${node}" "xlnx,mem-rows" $memrows noformating "pl.dtsi"
-        set power_domain "&versal_firmware 0x18224072"
-        add_prop "${node}" "power-domains" $power_domain string "pl.dtsi"
+        set power_domain "versal_firmware 0x18224072"
+        add_prop "${node}" "power-domains" $power_domain reference "pl.dtsi"
         add_prop "${node}" "#address-cells" 2 hexlist "pl.dtsi"
         add_prop "${node}" "#size-cells" 2 hexlist "pl.dtsi"
         add_prop "${node}" "ranges" 0 boolean "pl.dtsi"
@@ -133,17 +133,17 @@
 
         if {$part_num == "xcvp2502"} {
                 #s100
-                set power_domain "&versal_firmware 0x18225072"
+                set power_domain "versal_firmware 0x18225072"
                 add_prop "${aperture_node}" "xlnx,device-name" "100" int "pl.dtsi"
                 set aperture_nodeid 0x18801000
         } elseif {$part_num == "xcvp2802"} {
                 #s200
-                set power_domain "&versal_firmware 0x18227072"
+                set power_domain "versal_firmware 0x18227072"
                 add_prop "${aperture_node}" "xlnx,device-name" "200" int "pl.dtsi"
                 set aperture_nodeid 0x18803000
         } elseif {$part_num_v70 == "xcv70"} {
                 #v70
-                set power_domain "&versal_firmware 0x18224072"
+                set power_domain "versal_firmware 0x18224072"
                 add_prop "${aperture_node}" "xlnx,device-name" "0" int "pl.dtsi"
                 set aperture_nodeid 0x18800000
         } else {
@@ -152,7 +152,7 @@
                 lappend intr_names "interrupt2"
                 lappend intr_names "interrupt3"
                 set intr_num "0x0 0x94 0x4>, <0x0 0x95 0x4>, <0x0 0x96 0x4"
-                set power_domain "&versal_firmware 0x18224072"
+                set power_domain "versal_firmware 0x18224072"
                 add_prop "${aperture_node}" "interrupt-names" $intr_names stringlist "pl.dtsi"
                 add_prop "${aperture_node}" "interrupts" $intr_num hexlist "pl.dtsi"
                 add_prop "${aperture_node}" "interrupt-parent" imux reference "pl.dtsi"
@@ -160,7 +160,7 @@
                 set aperture_nodeid 0x18800000
         }
 
-        add_prop "${aperture_node}" "power-domains" $power_domain string "pl.dtsi"
+        add_prop "${aperture_node}" "power-domains" $power_domain reference "pl.dtsi"
         add_prop "${aperture_node}" "#address-cells" "2" hexlist "pl.dtsi"
         add_prop "${aperture_node}" "#size-cells" "2" hexlist "pl.dtsi"
 

--- a/axi_bram/data/axi_bram.tcl
+++ b/axi_bram/data/axi_bram.tcl
@@ -57,7 +57,6 @@
 		return
         }
 
-        set memory_node [create_node -n "memory" -l "${drv_handle}_memory" -u $baseaddr -p root -d "system-top.dts"]
         set ip_mem_handles [hsi::get_mem_ranges $slave]
         set drv_ip [get_ip_property $drv_handle IP_NAME]
         set proclist [hsi::get_cells -hier -filter {IP_TYPE==PROCESSOR}]
@@ -157,6 +156,7 @@
                                 }
                         }
                 }
+                set memory_node [create_node -n "memory" -l "${drv_handle}_memory" -u $baseaddr -p root -d "system-top.dts"]
                 add_prop "${memory_node}" "reg" $reg hexlist "system-top.dts" 1
                 set dev_type memory
                 add_prop "${memory_node}" "device_type" $dev_type string "system-top.dts" 1

--- a/axi_bram/data/axi_bram.tcl
+++ b/axi_bram/data/axi_bram.tcl
@@ -21,6 +21,7 @@
         set dup_ilmb_dlmb_node 0
         set 64_bit 0
         global apu_proc_ip
+        global is_64_bit_mb
 
         # HSI reports ilmb_ram and dlmb_ram as two different IPs even though it points to the same BRAM_CNTRL. The
         # linker needs just one entry among these two and other is just a redundant data for us.
@@ -94,7 +95,8 @@
                         set size [format 0x%x [expr {${high} - ${base} + 1}]]
                         set proctype [get_hw_family]
                         if {[is_zynqmp_platform $proctype] || \
-                                [string match -nocase $proctype "versal"] || [string length [string trimleft $base "0x"]] > 8} {
+                                [string match -nocase $proctype "versal"] || [string length [string trimleft $base "0x"]] > 8 \
+                                || $is_64_bit_mb} {
                                 set 64_bit 1
                                 if {[regexp -nocase {0x([0-9a-f]{9})} "$base" match]} {
                                         set temp $base

--- a/axi_bram/data/axi_bram.tcl
+++ b/axi_bram/data/axi_bram.tcl
@@ -22,6 +22,7 @@
         set 64_bit 0
         global apu_proc_ip
         global is_64_bit_mb
+        set mapped 0
 
         # HSI reports ilmb_ram and dlmb_ram as two different IPs even though it points to the same BRAM_CNTRL. The
         # linker needs just one entry among these two and other is just a redundant data for us.
@@ -161,6 +162,7 @@
                 add_prop "${memory_node}" "device_type" $dev_type string "system-top.dts" 1
                 add_prop "${memory_node}" "xlnx,ip-name" [get_ip_property $drv_handle IP_NAME] string "system-top.dts"
                 add_prop "${memory_node}" "memory_type" "memory" string "system-top.dts"
+                set mapped 1
                 set have_ecc [hsi get_property CONFIG.C_ECC [hsi::get_cells -hier $drv_handle]]
                 set ctrl_base [hsi get_property CONFIG.C_S_AXI_CTRL_BASEADDR [hsi::get_cells -hier $drv_handle]]
                 if { $ctrl_base > 0 &&  $have_ecc == 1} {
@@ -241,8 +243,12 @@
         set ver [lindex $vlnv 3]
         set comp_prop "xlnx,${name}-${ver}"
         regsub -all {_} $comp_prop {-} comp_prop
+        if {$mapped == 1} {
+               add_prop ${memory_node} "compatible" $comp_prop string "system-top.dts"
+        } else {
+               dtg_warning "bram not mapped to any processor"
+        }
 
-        add_prop ${memory_node} "compatible" $comp_prop string "system-top.dts"
     }
 
 

--- a/cpu/data/cpu.tcl
+++ b/cpu/data/cpu.tcl
@@ -20,6 +20,7 @@
 
     proc cpu_generate {drv_handle} {
         global mb_dict_64_bit
+        global is_64_bit_mb
         set proctype [get_hw_family]
         set bus_name [add_or_get_bus_node $drv_handle "pl.dtsi"]
         set nr [get_microblaze_nr $drv_handle]
@@ -90,6 +91,7 @@
         if {![string_is_empty $addr_size]} {
                 set cell_size 1
                 if {[expr $addr_size] > 32} {
+                        set is_64_bit_mb 1
                         set cell_size 2
                 }
                 dict set mb_dict_64_bit $drv_handle $cell_size

--- a/cpu/data/cpu.tcl
+++ b/cpu/data/cpu.tcl
@@ -22,6 +22,17 @@
         global mb_dict_64_bit
         global is_64_bit_mb
         set proctype [get_hw_family]
+        set addr_size [get_ip_property $drv_handle CONFIG.C_ADDR_SIZE]
+        if {![string_is_empty $addr_size]} {
+                set cell_size 1
+                if {[expr $addr_size] > 32} {
+                        set is_64_bit_mb 1
+                        set cell_size 2
+                }
+                dict set mb_dict_64_bit $drv_handle $cell_size
+        }
+        # is_64_bit_mb must be set before calling add_or_get_bus_node proc to set the
+        # correct address-cells and size-cells in amba_pl node
         set bus_name [add_or_get_bus_node $drv_handle "pl.dtsi"]
         set nr [get_microblaze_nr $drv_handle]
         set ip_name [get_ip_property $drv_handle IP_NAME]
@@ -86,16 +97,6 @@
         gen_mb_interrupt_property $drv_handle
         gen_drv_prop_from_ip $drv_handle
         generate_mb_ccf_node $drv_handle
-
-        set addr_size [get_ip_property $drv_handle CONFIG.C_ADDR_SIZE]
-        if {![string_is_empty $addr_size]} {
-                set cell_size 1
-                if {[expr $addr_size] > 32} {
-                        set is_64_bit_mb 1
-                        set cell_size 2
-                }
-                dict set mb_dict_64_bit $drv_handle $cell_size
-        }
     }
 
     proc cpu_check_64bit {base} {

--- a/cpu_cortexa53/data/cpu_cortexa53.tcl
+++ b/cpu_cortexa53/data/cpu_cortexa53.tcl
@@ -1,6 +1,6 @@
 #
 # (C) Copyright 2014-2022 Xilinx, Inc.
-# (C) Copyright 2022-2023 Advanced Micro Devices, Inc. All Rights Reserved.
+# (C) Copyright 2022-2024 Advanced Micro Devices, Inc. All Rights Reserved.
 #
 # This program is free software; you can redistribute it and/or
 # modify it under the terms of the GNU General Public License as
@@ -20,8 +20,9 @@
         update_system_dts_include [file tail "zynqmp-clk-ccf.dtsi"]
         set bus_name "amba"
         set ip_name [get_ip_property $drv_handle IP_NAME]
-        set cpu_nr [string index [get_ip_property $drv_handle NAME] end]
-        set cpu_node [pcwdt insert root end "&psu_cortexa53_${cpu_nr}"]
+        set fields [split [get_ip_property $drv_handle NAME] "_"]
+        set cpu_nr [lindex $fields end]
+        set cpu_node [create_node -n "&psu_cortexa53_${cpu_nr}" -d "pcw.dtsi" -p root -h $drv_handle]
         add_prop $cpu_node "cpu-frequency" [hsi get_property CONFIG.C_CPU_CLK_FREQ_HZ $drv_handle] int "pcw.dtsi"
         add_prop $cpu_node "stamp-frequency" [hsi get_property CONFIG.C_TIMESTAMP_CLK_FREQ $drv_handle] int "pcw.dtsi"
         add_prop $cpu_node "xlnx,ip-name" $ip_name string "pcw.dtsi"

--- a/cpu_cortexa72/data/cpu_cortexa72.tcl
+++ b/cpu_cortexa72/data/cpu_cortexa72.tcl
@@ -20,7 +20,7 @@
         update_system_dts_include "versal-clk.dtsi"
         set bus_name "amba"
         set cpu_nr [string index [get_ip_property $drv_handle NAME] end]
-        set cpu_node [pcwdt insert root end "&psv_cortexa72_${cpu_nr}"]
+        set cpu_node [create_node -n "&psv_cortexa72_${cpu_nr}" -d "pcw.dtsi" -p root -h $drv_handle]
         set ip_name [get_ip_property $drv_handle IP_NAME]
         add_prop $cpu_node "xlnx,ip-name" $ip_name string "pcw.dtsi"
         add_prop $cpu_node "bus-handle" $bus_name reference "pcw.dtsi"

--- a/cpu_cortexa78/data/cpu_cortexa78.tcl
+++ b/cpu_cortexa78/data/cpu_cortexa78.tcl
@@ -1,5 +1,5 @@
 #
-# (C) Copyright 2022-2023 Advanced Micro Devices, Inc. All Rights Reserved.
+# (C) Copyright 2022-2024 Advanced Micro Devices, Inc. All Rights Reserved.
 #
 # This program is free software; you can redistribute it and/or
 # modify it under the terms of the GNU General Public License as
@@ -21,7 +21,7 @@ proc cpu_cortexa78_generate {drv_handle} {
 	set bus_name "amba"
 	set fields [split [get_ip_property $drv_handle NAME] "_"]
         set cpu_nr [lindex $fields end]
-        set cpu_node [pcwdt insert root end "&psx_cortexa78_${cpu_nr}"]
+        set cpu_node [create_node -n "&psx_cortexa78_${cpu_nr}" -d "pcw.dtsi" -p root -h $drv_handle]
         set ip_name [get_ip_property $drv_handle IP_NAME]
         add_prop $cpu_node "xlnx,ip-name" $ip_name string "pcw.dtsi"
         add_prop $cpu_node "bus-handle" $bus_name reference "pcw.dtsi"

--- a/cpu_cortexa9/data/cpu_cortexa9.tcl
+++ b/cpu_cortexa9/data/cpu_cortexa9.tcl
@@ -1,6 +1,6 @@
 #
 # (C) Copyright 2014-2022 Xilinx, Inc.
-# (C) Copyright 2022-2023 Advanced Micro Devices, Inc. All Rights Reserved.
+# (C) Copyright 2022-2024 Advanced Micro Devices, Inc. All Rights Reserved.
 #
 # This program is free software; you can redistribute it and/or
 # modify it under the terms of the GNU General Public License as
@@ -18,10 +18,10 @@
         set dtsi_fname "zynq/zynq-7000.dtsi"
         update_system_dts_include [file tail ${dtsi_fname}]
         set bus_name "amba"
-        # TODO: Figure out a way to get the current number of processor
-        set cpu_nr [string index [get_ip_property $drv_handle NAME] end]
+        set fields [split [get_ip_property $drv_handle NAME] "_"]
+        set cpu_nr [lindex $fields end]
         set ip_name [get_ip_property $drv_handle IP_NAME]
-        set cpu_node [pcwdt insert root end "&ps7_cortexa9_${cpu_nr}"]
+        set cpu_node [create_node -n "&ps7_cortexa9_${cpu_nr}" -d "pcw.dtsi" -p root -h $drv_handle]
         add_prop $cpu_node "xlnx,ip-name" $ip_name string "pcw.dtsi"
         add_prop $cpu_node "bus-handle" $bus_name reference "pcw.dtsi"
         gen_drv_prop_from_ip $drv_handle

--- a/cpu_cortexr5/data/cpu_cortexr5.tcl
+++ b/cpu_cortexr5/data/cpu_cortexr5.tcl
@@ -1,6 +1,6 @@
 #
 # (C) Copyright 2014-2021 Xilinx, Inc.
-# (C) Copyright 2022-2023 Advanced Micro Devices, Inc. All Rights Reserved.
+# (C) Copyright 2022-2024 Advanced Micro Devices, Inc. All Rights Reserved.
 #
 # This program is free software; you can redistribute it and/or
 # modify it under the terms of the GNU General Public License as
@@ -15,13 +15,14 @@
 
     proc cpu_cortexr5_generate {drv_handle} {
         set ip_name [get_ip_property $drv_handle IP_NAME]
-        set cpu_nr [string index [get_ip_property $drv_handle NAME] end]
+        set fields [split [get_ip_property $drv_handle NAME] "_"]
+        set cpu_nr [lindex $fields end]
         if {[string match -nocase $ip_name "psu_cortexr5"]} {
-                set node [pcwdt insert root end "&psu_cortexr5_${cpu_nr}"]
+                set node [create_node -n "&psu_cortexr5_${cpu_nr}" -d "pcw.dtsi" -p root -h $drv_handle]
         } elseif {[string match -nocase $ip_name "psv_cortexr5"]} {
-                set node [pcwdt insert root end "&psv_cortexr5_${cpu_nr}"]
+                set node [create_node -n "&psv_cortexr5_${cpu_nr}" -d "pcw.dtsi" -p root -h $drv_handle]
         } elseif {[string match -nocase $ip_name "psx_cortexr52"]} {
-                set node [pcwdt insert root end "&psx_cortexr52_${cpu_nr}"]
+                set node [create_node -n "&psx_cortexr52_${cpu_nr}" -d "pcw.dtsi" -p root -h $drv_handle]
         } else {
                 error "Driver cpu_cortexr5 is not valid for given handle $drv_handle"
         }

--- a/ddrpsv/data/ddrpsv.tcl
+++ b/ddrpsv/data/ddrpsv.tcl
@@ -555,11 +555,13 @@
     proc ddrpsv_check_tcm_overlapping {proc ddr_base_addr} {
         set proc_ip [get_ip_property $proc IP_NAME]
         if {[string match -nocase $proc_ip "psv_cortexr5"] || [string match -nocase $proc_ip "psx_cortexr52"]} {
-                set tcm_ip [hsi::get_cells -hier -filter {NAME=~"*tcm_ram_0" || NAME=~"*tcm_alias"}]
+                set tcm_ip [hsi::get_cells -hier -filter {NAME=~"*tcm_ram_global" || NAME=~"*tcm_alias"}]
                 if {[llength $tcm_ip] == 1} {
                         set tcm_high_addr [get_highaddr $tcm_ip]
-                        if {[string compare $tcm_high_addr $ddr_base_addr] > 0} {
-                                set ddr_base_addr [format 0x%x [expr {$tcm_high_addr + 1}]]
+                        set tcm_base_addr [get_baseaddr $tcm_ip]
+                        set tcm_size [format 0x%x [expr {${tcm_high_addr} - ${tcm_base_addr} + 1}]]
+                        if {[scan $tcm_size %x] > [scan $ddr_base_addr %x]} {
+                                set ddr_base_addr $tcm_size
                         }
                 }
         }

--- a/device_tree/data/common_proc.tcl
+++ b/device_tree/data/common_proc.tcl
@@ -2040,45 +2040,7 @@ proc add_cross_property args {
 				} elseif {[string match -nocase $ipname "psx_rcpu_gic"]} {
 					set node [create_node -n "&gic_r52" -d "pcw.dtsi" -p root]
 				} elseif {[lsearch $valid_proclist $ipname] >= 0} {
-					switch $ipname {
-						"psv_cortexa72" {
-							set index [string index $src_handle end]
-							set node [create_node -n "&psv_cortexa72_${index}" -d "pcw.dtsi" -p root]
-						} "psv_cortexr5" {
-							set index [string index $src_handle end]
-							set node [create_node -n "&psv_cortexr5_${index}" -d "pcw.dtsi" -p root]
-						} "psv_pmc" {
-							set node [create_node -n "&psv_pmc_0" -d "pcw.dtsi" -p root]
-						} "psv_psm" {
-							set node [create_node -n "&psv_psm_0" -d "pcw.dtsi" -p root]
-						} "psx_pmc" {
-							set node [create_node -n "&psx_pmc_0" -d "pcw.dtsi" -p root]
-						} "psx_psm" {
-							set node [create_node -n "&psx_psm_0" -d "pcw.dtsi" -p root]
-						} "psu_cortexa53" {
-							set index [string index $src_handle end]
-							set node [create_node -n "&psu_cortexa53_${index}" -d "pcw.dtsi" -p root]
-						} "psu_cortexr5" {
-							set index [string index $src_handle end]
-							set node [create_node -n "&psu_cortexr5_${index}" -d "pcw.dtsi" -p root]
-						} "psu_pmu" {
-							set node [create_node -n "&psu_pmu_0" -d "pcw.dtsi" -p root]
-						} "microblaze" - "microblaze_riscv" {
-							set count [get_microblaze_nr $src_handle]
-							set bus_name [detect_bus_name $src_handle]
-							set rt_node [create_node -n "cpus_${ipname}" -l "cpus_${ipname}_${count}" -u $count -d "pl.dtsi" -p $bus_name]
-							set node [create_node -n "cpu" -l "$src_handle" -u $count -d "pl.dtsi" -p $rt_node]
-                                                } "ps7_cortexa9" {
-							set index [string index $src_handle end]
-							set node [create_node -n "&ps7_cortexa9_${index}" -d "pcw.dtsi" -p root]
-						} "psx_cortexa78" {
-							set index [string index $src_handle end]
-							set node [create_node -n "&psx_cortexa78_${index}" -d "pcw.dtsi" -p root]
-						} "psx_cortexr52" {
-							set index [string index $src_handle end]
-							set node [create_node -n "&psx_cortexr52_${index}" -d "pcw.dtsi" -p root]
-						}
-					}
+					set node [get_node $src_handle]
 				} else {
 					set node [get_node $dest_handle]
 				}
@@ -6286,56 +6248,15 @@ proc gen_peripheral_nodes {drv_handle {node_only ""}} {
 		if {[string match -nocase $ip_type "tsn_endpoint_ethernet_mac"]} {
 			set rt_node [create_node -n tsn_endpoint_ip_0 -l tsn_endpoint_ip_0 -d $default_dts -p $bus_node] 
 		} else {
-			set valid_proclist "psv_cortexa72 psv_cortexr5 psu_cortexa53 psu_cortexr5 psu_pmu psv_pmc psv_psm ps7_cortexa9 psx_cortexa78 psx_cortexr52 psx_pmc psx_psm"
+			set valid_proclist "psv_cortexa72 psv_cortexr5 psu_cortexa53 psu_cortexr5 psu_pmu psv_pmc psv_psm ps7_cortexa9 psx_cortexa78 psx_cortexr52 psx_pmc psx_psm microblaze microblaze_riscv"
 			if {[lsearch $valid_proclist $ip_type] >= 0} {
-				switch $ip_type {
-					"psv_cortexa72" {
-						set index [string index $drv_handle end]
-						set rt_node [create_node -n "&psv_cortexa72_${index}" -d ${default_dts} -p root]
-					} "psv_cortexr5" {
-						set index [string index $drv_handle end]
-						set rt_node [create_node -n "&psv_cortexr5_${index}" -d ${default_dts} -p root]
-					} "psv_pmc" {
-						set rt_node [create_node -n "&psv_pmc_0" -d ${default_dts} -p root]
-					} "psv_psm" {
-						set rt_node [create_node -n "&psv_psm_0" -d "pcw.dtsi" -p root]
-					} "psu_cortexa53" {
-						set index [string index $src_handle end]
-						set node [create_node -n "&psu_cortexa53_${index}" -d "pcw.dtsi" -p root]
-					} "psu_cortexr5" {
-						set index [string index $src_handle end]
-						set node [create_node -n "&psu_cortexr5_${index}" -d "pcw.dtsi" -p root]
-					} "psu_pmu" {
-						set node [create_node -n "&psu_pmu_0" -d "pcw.dtsi" -p root]
-					} "ps7_cortexa9" {
-						set index [string index $drv_handle end]
-						set node [create_node -n "&ps7_cortexa9_${index}" -d "pcw.dtsi" -p root]
-					} "psx_cortexa78" {
-						set index [string index $drv_handle end]
-						set rt_node [create_node -n "&psx_cortexa78_${index}" -d ${default_dts} -p root]
-					} "psx_cortexr52" {
-						set index [string index $drv_handle end]
-						set rt_node [create_node -n "&psx_cortexr52_${index}" -d ${default_dts} -p root]
-					} "psx_psm" {
-						set rt_node [create_node -n "&psx_psm_0" -d ${default_dts} -p root]
-					} "psx_pmc" {
-						set rt_node [create_node -n "&psx_pmc_0" -d ${default_dts} -p root]
-					} 
-				}
+				set rt_node [get_node $drv_handle]
 			} else {
-				if {[string match -nocase $ip_type "microblaze"] || [string match -nocase $ip_type "microblaze_riscv"]} {
-					set proctype [get_hw_family]
-					set bus_name [detect_bus_name $drv_handle]
-					set count [get_microblaze_nr $drv_handle]
-					set rt_node [create_node -n "cpus_${ip_type}" -l "cpus_${ip_type}_${count}" -u $count -d ${default_dts} -p $bus_name]
-					set rt_node [create_node -n "cpu" -l "$drv_handle" -u $count -d "pl.dtsi" -p $rt_node]
-				} else {
-					if {[string match -nocase $dev_type "psv_fpd_smmutcu"]} {
-							set dev_type "psv_fpd_maincci"
-					}
-					set t [get_ip_property $drv_handle IP_NAME]
-					set rt_node [create_node -n ${dev_type} -l ${label} -u ${unit_addr} -d ${default_dts} -p $bus_node]
+				if {[string match -nocase $dev_type "psv_fpd_smmutcu"]} {
+						set dev_type "psv_fpd_maincci"
 				}
+				set t [get_ip_property $drv_handle IP_NAME]
+				set rt_node [create_node -n ${dev_type} -l ${label} -u ${unit_addr} -d ${default_dts} -p $bus_node]
 			}
 		}
 

--- a/device_tree/data/common_proc.tcl
+++ b/device_tree/data/common_proc.tcl
@@ -6361,6 +6361,7 @@ proc get_axi_datawidth {val} {
 }
 
 proc add_or_get_bus_node {ip_drv dts_file} {
+	global is_64_bit_mb
 	proc_called_by
 	set bus_name [detect_bus_name $ip_drv]
 	dtg_debug "bus_name: $bus_name"
@@ -6377,7 +6378,7 @@ proc add_or_get_bus_node {ip_drv dts_file} {
 		add_prop $fpga_node target "$targets" reference $dts 1
 		set child_name "__overlay__"
 		set bus_node [create_node -l "overlay2" -n $child_name -p $fpga_node -d $dts]
-		if {[is_zynqmp_platform $proctype] || [string match -nocase $proctype "versal"]} {
+		if {[is_zynqmp_platform $proctype] || [string match -nocase $proctype "versal"] || $is_64_bit_mb} {
 			add_prop "${bus_node}" "#address-cells" 2 int $dts 1
 			add_prop "${bus_node}" "#size-cells" 2 int $dts 1
 		} else {
@@ -6387,7 +6388,7 @@ proc add_or_get_bus_node {ip_drv dts_file} {
 	} else {
 		set bus_node $bus_name
 		if {[string match -nocase $bus_node "amba_pl: amba_pl"]} {
-			if {[is_zynqmp_platform $proctype] || [string match -nocase $proctype "versal"]} {
+			if {[is_zynqmp_platform $proctype] || [string match -nocase $proctype "versal"] || $is_64_bit_mb} {
 				set addr_cells 2
 				set size_cells 2
 			} else {

--- a/device_tree/data/common_proc.tcl
+++ b/device_tree/data/common_proc.tcl
@@ -5306,6 +5306,7 @@ proc gen_interrupt_property {drv_handle {intr_port_name ""}} {
 
 proc gen_reg_property {drv_handle {skip_ps_check ""} {set_node_prop 1}} {
 	global apu_proc_ip
+	global is_64_bit_mb
 	proc_called_by
         set unit_addr [get_baseaddr ${drv_handle} no_prefix]
 	if {$unit_addr == "" } {
@@ -5364,7 +5365,7 @@ proc gen_reg_property {drv_handle {skip_ps_check ""} {set_node_prop 1}} {
 			set size [format 0x%x [expr {${high} - ${base} + 1}]]
 		}
 		if {![string_is_empty $base]} {
-			if {[string match -nocase $proctype "versal"] || [is_zynqmp_platform $proctype] || [string length [string trimleft $base "0x"]] > 8} {
+			if {[string match -nocase $proctype "versal"] || [is_zynqmp_platform $proctype] || [string length [string trimleft $base "0x"]] > 8 || $is_64_bit_mb} {
 				# check if base address is 64bit and split it as MSB and LSB
 				if {[regexp -nocase {0x([0-9a-f]{9})} "$base" match]} {
 					set temp $base
@@ -5442,7 +5443,7 @@ proc gen_reg_property {drv_handle {skip_ps_check ""} {set_node_prop 1}} {
 			}
 
 			set new_reg ""
-			if {[string match -nocase $proctype "versal"] || [is_zynqmp_platform $proctype] || [string length [string trimleft $base "0x"]] > 8} {
+			if {[string match -nocase $proctype "versal"] || [is_zynqmp_platform $proctype] || [string length [string trimleft $base "0x"]] > 8 || $is_64_bit_mb} {
 				# check if base address is 64bit and split it as MSB and LSB
 				if {[regexp -nocase {0x([0-9a-f]{9})} "$base" match]} {
 					set temp $base

--- a/device_tree/data/common_proc.tcl
+++ b/device_tree/data/common_proc.tcl
@@ -766,6 +766,7 @@ proc create_node args {
 	set node_name ""
 	set node_unit_addr ""
 	set node_label ""
+	set drv_handle ""
 	while {[string match -* [lindex $args 0]]} {
 		switch -glob -- [lindex $args 0] {
 			-force {set force_create 1}
@@ -778,6 +779,7 @@ proc create_node args {
 			-p* {set parent_obj [Pop args 1]
 				}
 			-d* {set dts_file [Pop args 1]}
+			-h* {set drv_handle [Pop args 1]}
 			--  {Pop args ; break}
 			default {
 				error "add_or_get_dt_node bad option - [lindex $args 0]"
@@ -979,7 +981,12 @@ proc create_node args {
 	set drvnode [string trimleft $drvnode "\{"]
 	set drvnode [string trimright $drvnode "\}"]
 
-	dict set node_dict $cur_hw_design $node_label $drvnode
+	if {![string_is_empty $node_label]} {
+		dict set node_dict $cur_hw_design $node_label $drvnode
+	} elseif {![string_is_empty $drv_handle]} {
+		dict set node_dict $cur_hw_design $drv_handle $drvnode
+	}
+
         return $drvnode
 }
 

--- a/device_tree/data/common_proc.tcl
+++ b/device_tree/data/common_proc.tcl
@@ -1350,7 +1350,7 @@ proc write_dt args {
 		}
 	}
 	if {[string match -nocase $dt "pldt"] && $dt_overlay} {
-		puts $fd "\/dts-v1\/\n\/plugin\/;"
+		puts $fd "\/dts-v1\/;\n\/plugin\/;"
 	}
 	set dtcheck [string match -nocase $dt "pcwdt"]
 	if {$dtcheck != 1} {

--- a/device_tree/data/device_tree.tcl
+++ b/device_tree/data/device_tree.tcl
@@ -775,7 +775,9 @@ proc get_sem_property { prop } {
 		set pspmcCell [hsi::get_cells -hier -filter "IP_NAME==ps11"]
 	}
 	if {$pspmcCell ne ""} {
-		return [common::get_property $prop $pspmcCell]
+		set readconfig [common::get_property $prop $pspmcCell]
+		set readconfig [lindex $readconfig 0]
+		return $readconfig
 	} else {
 		set cipsCell [hsi::get_cells -hier -filter "IP_NAME==versal_cips"]
 		if {$cipsCell ne ""} {

--- a/device_tree/data/device_tree.tcl
+++ b/device_tree/data/device_tree.tcl
@@ -200,6 +200,7 @@ proc init_proclist {} {
 	dict set ::sdtgen::namespacelist "psv_pmc_qspi" "qspips"
 	dict set ::sdtgen::namespacelist "ps7_ram" "ramps"
 	dict set ::sdtgen::namespacelist "usp_rf_data_converter" "rfdc"
+	dict set ::sdtgen::namespacelist "xdfe_cc_filter" "dfeccf"
 	dict set ::sdtgen::namespacelist "xdfe_cc_mixer" "dfemix"
 	dict set ::sdtgen::namespacelist "xdfe_nr_prach" "dfeprach"
 	dict set ::sdtgen::namespacelist "ps7_scugic" "scugic"

--- a/device_tree/data/device_tree.tcl
+++ b/device_tree/data/device_tree.tcl
@@ -1300,6 +1300,7 @@ proc generate_sdt args {
 	global rp_region_dict
 	global is_rm_design
 	global mb_dict_64_bit
+	global is_64_bit_mb
 	global baseaddr_dict
 	global highaddr_dict
 	global processor_ip_list
@@ -1384,6 +1385,7 @@ Generates system device tree based on args given in:
 
 	set proclist [hsi::get_cells -hier -filter {IP_TYPE==PROCESSOR}]
 	set processor_ip_list [list]
+	set is_64_bit_mb 0
 
 	# TODO: Consolidate this.
 	# This can't be merged to the loop running for each cpu.tcl.

--- a/device_tree/data/device_tree.tcl
+++ b/device_tree/data/device_tree.tcl
@@ -160,6 +160,8 @@ proc init_proclist {} {
 	dict set ::sdtgen::namespacelist "psu_i2c" "iicps"
 	dict set ::sdtgen::namespacelist "psv_i2c" "iicps"
 	dict set ::sdtgen::namespacelist "psx_i2c" "iicps"
+	dict set ::sdtgen::namespacelist "psv_pmc_i2c" "iicps"
+	dict set ::sdtgen::namespacelist "psx_pmc_i2c" "iicps"
 	dict set ::sdtgen::namespacelist "axi_intc" "intc"
 	dict set ::sdtgen::namespacelist "iomodule" "iomodule"
 	dict set ::sdtgen::namespacelist "psx_iomodule" "iomodule"

--- a/device_tree/data/device_tree.tcl
+++ b/device_tree/data/device_tree.tcl
@@ -1400,7 +1400,7 @@ Generates system device tree based on args given in:
 		}
 	}
 
-	set non_val_list "versal_cips psx_wizard psxl ps_wizard dmac_slv axi_noc axi_noc2 noc_mc_ddr4 noc_mc_ddr5 ddr3 ddr4 mig_7series noc_nmu noc_nsu noc2_nmu noc2_nsu ila zynq_ultra_ps_e psu_iou_s smart_connect emb_mem_gen xlconcat xlconstant xlslice axis_tdest_editor util_reduced_logic noc_nsw noc2_nsw axis_ila pspmc psv_ocm_ram_0 psv_pmc_qspi_ospi psx_pmc_qspi_ospi add_keep_128 c_counter_binary dbg_monmux ${linear_spi_list}"
+	set non_val_list "versal_cips psx_wizard psxl ps_wizard dmac_slv axi_noc axi_noc2 noc_mc_ddr4 noc_mc_ddr5 ddr3 ddr4 mig_7series hbm noc_nmu noc_nsu noc2_nmu noc2_nsu ila zynq_ultra_ps_e psu_iou_s smart_connect emb_mem_gen xlconcat xlconstant xlslice axis_tdest_editor util_reduced_logic noc_nsw noc2_nsw axis_ila pspmc psv_ocm_ram_0 psv_pmc_qspi_ospi psx_pmc_qspi_ospi add_keep_128 c_counter_binary dbg_monmux ${linear_spi_list}"
 	set non_val_ip_types "MONITOR BUS PROCESSOR"
 	set non_val_list1 "psv_cortexa72 psu_cortexa53 ps7_cortexa9 versal_cips psx_wizard ps_wizard noc_nmu noc_nsu ila psu_iou_s noc_nsw pspmc"
 	set non_val_ip_types1 "MONITOR BUS"

--- a/device_tree/data/device_tree.tcl
+++ b/device_tree/data/device_tree.tcl
@@ -1405,9 +1405,9 @@ Generates system device tree based on args given in:
 		}
 	}
 
-	set non_val_list "versal_cips psx_wizard psxl ps_wizard dmac_slv axi_noc axi_noc2 noc_mc_ddr4 noc_mc_ddr5 ddr3 ddr4 mig_7series hbm noc_nmu noc_nsu noc2_nmu noc2_nsu ila zynq_ultra_ps_e psu_iou_s smart_connect emb_mem_gen xlconcat xlconstant xlslice axis_tdest_editor util_reduced_logic noc_nsw noc2_nsw axis_ila pspmc psv_ocm_ram_0 psv_pmc_qspi_ospi psx_pmc_qspi_ospi add_keep_128 c_counter_binary dbg_monmux ${linear_spi_list}"
+	set non_val_list "versal_cips psx_wizard psxl ps_wizard dmac_slv axi_noc axi_noc2 noc_mc_ddr4 noc_mc_ddr5 ddr3 ddr4 mig_7series hbm noc_nmu noc_nsu noc2_nmu noc2_nsu ila zynq_ultra_ps_e psu_iou_s smart_connect emb_mem_gen xlconcat xlconstant xlslice axis_tdest_editor util_reduced_logic noc_nsw noc2_nsw axis_ila pspmc pmcps psv_ocm_ram_0 psv_pmc_qspi_ospi psx_pmc_qspi_ospi add_keep_128 c_counter_binary dbg_monmux ${linear_spi_list}"
 	set non_val_ip_types "MONITOR BUS PROCESSOR"
-	set non_val_list1 "psv_cortexa72 psu_cortexa53 ps7_cortexa9 versal_cips psx_wizard ps_wizard noc_nmu noc_nsu ila psu_iou_s noc_nsw pspmc"
+	set non_val_list1 "psv_cortexa72 psu_cortexa53 ps7_cortexa9 versal_cips psx_wizard ps_wizard noc_nmu noc_nsu ila psu_iou_s noc_nsw pspmc pmcps"
 	set non_val_ip_types1 "MONITOR BUS"
 
 	set_hw_family $proclist

--- a/device_tree/data/kernel_dtsi/2024.1/BOARD/versal-a2197-sc-reva.dtsi
+++ b/device_tree/data/kernel_dtsi/2024.1/BOARD/versal-a2197-sc-reva.dtsi
@@ -47,11 +47,11 @@
 };
 
 &uart0 { /* uart0 MIO38-39 */
-	u-boot,dm-pre-reloc;
+	bootph-all;
 };
 
 &uart1 { /* uart1 MIO40-41 */
-	u-boot,dm-pre-reloc;
+	bootph-all;
 };
 
 &sdhci1 { /* sd1 MIO45-51 cd in place */

--- a/device_tree/data/kernel_dtsi/2024.1/BOARD/versal-emu-itr8-cn13940875.dtsi
+++ b/device_tree/data/kernel_dtsi/2024.1/BOARD/versal-emu-itr8-cn13940875.dtsi
@@ -21,14 +21,14 @@
 	};
 
 	clk0212: clk0212 {
-		u-boot,dm-pre-reloc;
+		bootph-all;
 		compatible = "fixed-clock";
 		#clock-cells = <0x0>;
 		clock-frequency = <212000>;
 	};
 
 	clk25: clk25 {
-		u-boot,dm-pre-reloc;
+		bootph-all;
 		compatible = "fixed-clock";
 		#clock-cells = <0x0>;
 		clock-frequency = <25000000>;

--- a/device_tree/data/kernel_dtsi/2024.1/BOARD/versal-net-emu-rev1.9.dtsi
+++ b/device_tree/data/kernel_dtsi/2024.1/BOARD/versal-net-emu-rev1.9.dtsi
@@ -126,7 +126,7 @@
 	};
 
 	clk1: clk1 {
-		u-boot,dm-pre-reloc;
+		bootph-all;
 		compatible = "fixed-clock";
 		#clock-cells = <0>;
 		clock-frequency = <1000000>; /* it doesn't matter on EMU */
@@ -139,7 +139,7 @@
 
 	amba: axi {
 		compatible = "simple-bus";
-		u-boot,dm-pre-reloc;
+		bootph-all;
 		#address-cells = <2>;
 		#size-cells = <2>;
 		ranges;
@@ -153,7 +153,7 @@
 		};
 
 		serial0: serial@f1920000 {
-			u-boot,dm-pre-reloc;
+			bootph-all;
 			compatible = "arm,pl011", "arm,primecell";
 			reg = <0 0xf1920000 0 0x1000>;
 			interrupts = <0 25 4>;

--- a/device_tree/data/kernel_dtsi/2024.1/BOARD/versal-net-ipp-rev1.9.dtsi
+++ b/device_tree/data/kernel_dtsi/2024.1/BOARD/versal-net-ipp-rev1.9.dtsi
@@ -128,7 +128,7 @@
 
 	ref_clk: ref_clk {
 		compatible = "fixed-clock";
-		u-boot,dm-pre-reloc;
+		bootph-all;
 		#clock-cells = <0>;
 		clock-frequency = <33333333>;
 	};
@@ -137,12 +137,12 @@
 		versal_net_firmware: versal-net-firmware {
 			compatible = "xlnx,versal-net-firmware", "xlnx,versal-firmware";
 			interrupt-parent = <&gic>;
-			u-boot,dm-pre-reloc;
+			bootph-all;
 			method = "smc";
 			#power-domain-cells = <0x01>;
 
 			versal_net_clk: clock-controller {
-				u-boot,dm-pre-reloc;
+				bootph-all;
 				#clock-cells = <1>;
 				compatible = "xlnx,versal-net-clk", "xlnx,versal-clk";
 				clocks = <&ref_clk>, <&ref_clk>;
@@ -196,7 +196,7 @@
 
 	amba: axi {
 		compatible = "simple-bus";
-		u-boot,dm-pre-reloc;
+		bootph-all;
 		#address-cells = <2>;
 		#size-cells = <2>;
 		ranges;
@@ -548,7 +548,7 @@
 		};
 
 		serial0: serial@f1920000 {
-			u-boot,dm-pre-reloc;
+			bootph-all;
 			compatible = "arm,pl011", "arm,primecell";
 			reg = <0 0xf1920000 0 0x1000>;
 			interrupts = <0 25 4>;
@@ -562,7 +562,7 @@
 		};
 
 		serial1: serial@f1930000 {
-			u-boot,dm-pre-reloc;
+			bootph-all;
 			compatible = "arm,pl011", "arm,primecell";
 			reg = <0 0xf1930000 0 0x1000>;
 			interrupts = <0 26 4>;

--- a/device_tree/data/kernel_dtsi/2024.1/BOARD/versal-net-vn-x-b2197-00-reva.dtsi
+++ b/device_tree/data/kernel_dtsi/2024.1/BOARD/versal-net-vn-x-b2197-00-reva.dtsi
@@ -84,7 +84,7 @@
 	eeprom0: eeprom@51 {
 		compatible = "st,24c128", "atmel,24c128";
 		reg = <0x51>;
-		u-boot,dm-pre-reloc;
+		bootph-all;
 	};
 };
 
@@ -93,7 +93,7 @@
 	eeprom1: eeprom@55 {
 		compatible = "st,24c128", "atmel,24c128";
 		reg = <0x55>;
-		u-boot,dm-pre-reloc;
+		bootph-all;
 	};
 };
 

--- a/device_tree/data/kernel_dtsi/2024.1/BOARD/versal-spp-itr8-cn13940875.dtsi
+++ b/device_tree/data/kernel_dtsi/2024.1/BOARD/versal-spp-itr8-cn13940875.dtsi
@@ -37,7 +37,7 @@
 	};
 
 	clk25: clk25 {
-		u-boot,dm-pre-reloc;
+		bootph-all;
 		compatible = "fixed-clock";
 		#clock-cells = <0>;
 		clock-frequency = <25000000>;

--- a/device_tree/data/kernel_dtsi/2024.1/BOARD/versal-virt.dtsi
+++ b/device_tree/data/kernel_dtsi/2024.1/BOARD/versal-virt.dtsi
@@ -36,7 +36,7 @@
 	};
 
 	clk25: clk25 {
-		u-boot,dm-pre-reloc;
+		bootph-all;
 		compatible = "fixed-clock";
 		#clock-cells = <0x0>;
 		clock-frequency = <25000000>;
@@ -88,7 +88,7 @@
 	};
 
 	amba: amba {
-		u-boot,dm-pre-reloc;
+		bootph-all;
 		compatible = "simple-bus";
 		#address-cells = <0x2>;
 		#size-cells = <0x2>;

--- a/device_tree/data/kernel_dtsi/2024.1/BOARD/versal-vpk120-revb.dtsi
+++ b/device_tree/data/kernel_dtsi/2024.1/BOARD/versal-vpk120-revb.dtsi
@@ -74,7 +74,7 @@
 	eeprom: eeprom@54 { /* u34 - m24128 16kB */
 		compatible = "st,24c128", "atmel,24c128";
 		reg = <0x54>; /* & 0x5c */
-		u-boot,dm-pre-reloc;
+		bootph-all;
 	};
 
 };

--- a/device_tree/data/kernel_dtsi/2024.1/BOARD/versal-vpk180-reva.dtsi
+++ b/device_tree/data/kernel_dtsi/2024.1/BOARD/versal-vpk180-reva.dtsi
@@ -75,7 +75,7 @@
 	eeprom: eeprom@54 { /* u34 - m24128 16kB */
 		compatible = "st,24c128", "atmel,24c128";
 		reg = <0x54>; /* & 0x5c */
-		u-boot,dm-pre-reloc;
+		bootph-all;
 	};
 };
 

--- a/device_tree/data/kernel_dtsi/2024.1/BOARD/zc702.dtsi
+++ b/device_tree/data/kernel_dtsi/2024.1/BOARD/zc702.dtsi
@@ -383,7 +383,7 @@
 };
 
 &qspi {
-	u-boot,dm-pre-reloc;
+	bootph-all;
 	is-dual = <0>;
 	num-cs = <1>;
 	flash@0 {
@@ -418,13 +418,13 @@
 };
 
 &sdhci0 {
-	u-boot,dm-pre-reloc;
+	bootph-all;
 	pinctrl-names = "default";
 	pinctrl-0 = <&pinctrl_sdhci0_default>;
 };
 
 &uart1 {
-	u-boot,dm-pre-reloc;
+	bootph-all;
 	pinctrl-names = "default";
 	pinctrl-0 = <&pinctrl_uart1_default>;
 };

--- a/device_tree/data/kernel_dtsi/2024.1/BOARD/zc706.dtsi
+++ b/device_tree/data/kernel_dtsi/2024.1/BOARD/zc706.dtsi
@@ -293,7 +293,7 @@
 };
 
 &qspi {
-	u-boot,dm-pre-reloc;
+	bootph-all;
 	is-dual = <1>;
 	num-cs = <2>;
 	flash@0 {
@@ -329,13 +329,13 @@
 };
 
 &sdhci0 {
-	u-boot,dm-pre-reloc;
+	bootph-all;
 	pinctrl-names = "default";
 	pinctrl-0 = <&pinctrl_sdhci0_default>;
 };
 
 &uart1 {
-	u-boot,dm-pre-reloc;
+	bootph-all;
 	pinctrl-names = "default";
 	pinctrl-0 = <&pinctrl_uart1_default>;
 };

--- a/device_tree/data/kernel_dtsi/2024.1/BOARD/zedboard.dtsi
+++ b/device_tree/data/kernel_dtsi/2024.1/BOARD/zedboard.dtsi
@@ -24,7 +24,7 @@
 };
 
 &qspi {
-	u-boot,dm-pre-reloc;
+	bootph-all;
 	num-cs = <1>;
 	flash@0 {
 		compatible = "n25q128a11", "jedec,spi-nor";
@@ -58,11 +58,11 @@
 };
 
 &sdhci0 {
-	u-boot,dm-pre-reloc;
+	bootph-all;
 };
 
 &uart1 {
-	u-boot,dm-pre-reloc;
+	bootph-all;
 };
 
 &usb0 {

--- a/device_tree/data/kernel_dtsi/2024.1/BOARD/zynq-zc770-xm010.dtsi
+++ b/device_tree/data/kernel_dtsi/2024.1/BOARD/zynq-zc770-xm010.dtsi
@@ -121,7 +121,7 @@
 };
 
 &uart1 {
-	u-boot,dm-pre-reloc;
+	bootph-all;
 	status = "okay";
 };
 

--- a/device_tree/data/kernel_dtsi/2024.1/BOARD/zynq-zc770-xm011.dtsi
+++ b/device_tree/data/kernel_dtsi/2024.1/BOARD/zynq-zc770-xm011.dtsi
@@ -82,7 +82,7 @@
 };
 
 &uart1 {
-	u-boot,dm-pre-reloc;
+	bootph-all;
 	status = "okay";
 };
 

--- a/device_tree/data/kernel_dtsi/2024.1/BOARD/zynq-zc770-xm012.dtsi
+++ b/device_tree/data/kernel_dtsi/2024.1/BOARD/zynq-zc770-xm012.dtsi
@@ -90,6 +90,6 @@
 };
 
 &uart1 {
-	u-boot,dm-pre-reloc;
+	bootph-all;
 	status = "okay";
 };

--- a/device_tree/data/kernel_dtsi/2024.1/BOARD/zynq-zc770-xm013.dtsi
+++ b/device_tree/data/kernel_dtsi/2024.1/BOARD/zynq-zc770-xm013.dtsi
@@ -110,6 +110,6 @@
 };
 
 &uart0 {
-	u-boot,dm-pre-reloc;
+	bootph-all;
 	status = "okay";
 };

--- a/device_tree/data/kernel_dtsi/2024.1/BOARD/zynqmp-a2197-reva.dtsi
+++ b/device_tree/data/kernel_dtsi/2024.1/BOARD/zynqmp-a2197-reva.dtsi
@@ -22,14 +22,14 @@
 };
 
 &i2c0 {
-	u-boot,dm-pre-reloc;
+	bootph-all;
 	clock-frequency = <400000>;
 	i2c-mux@74 { /* this cover MGT board */
 		compatible = "nxp,pca9548";
 		#address-cells = <1>;
 		#size-cells = <0>;
 		reg = <0x74>;
-		u-boot,dm-pre-reloc;
+		bootph-all;
 		/* FIXME reset connected to SYSCTRL_IIC_MUX0_RESET */
 		i2c@0 {
 			#address-cells = <1>;
@@ -38,7 +38,7 @@
 			/* Use for storing information about SC board */
 			eeprom0: eeprom@50 { /* u96 - 24LC32A - 256B */
 				compatible = "atmel,24c32";
-				u-boot,dm-pre-reloc;
+				bootph-all;
 				reg = <0x50>;
 			};
 		};
@@ -46,14 +46,14 @@
 };
 
 &i2c1 {
-	u-boot,dm-pre-reloc;
+	bootph-all;
 	clock-frequency = <400000>;
 	i2c-mux@74 { /* This cover processor board */
 		compatible = "nxp,pca9548";
 		#address-cells = <1>;
 		#size-cells = <0>;
 		reg = <0x74>;
-		u-boot,dm-pre-reloc;
+		bootph-all;
 		/* FIXME reset connected to SYSCTRL_IIC_MUX0_RESET */
 		i2c@0 {
 			#address-cells = <1>;
@@ -62,7 +62,7 @@
 			/* Use for storing information about SC board */
 			eeprom1: eeprom@50 { /* u96 - 24LC32A - 256B */
 				compatible = "atmel,24c32";
-				u-boot,dm-pre-reloc;
+				bootph-all;
 				reg = <0x50>;
 			};
 		};

--- a/device_tree/data/kernel_dtsi/2024.1/BOARD/zynqmp-sc-revb.dtsi
+++ b/device_tree/data/kernel_dtsi/2024.1/BOARD/zynqmp-sc-revb.dtsi
@@ -147,7 +147,7 @@
 };
 
 &i2c1 { /* i2c1 MIO 24-25 */
-	u-boot,dm-pre-reloc;
+	bootph-all;
 	clock-frequency = <100000>;
 	pinctrl-names = "default", "gpio";
 	pinctrl-0 = <&pinctrl_i2c1_default>;
@@ -159,7 +159,7 @@
 	eeprom: eeprom@54 { /* u34 - m24128 16kB */
 		compatible = "st,24c128", "atmel,24c128";
 		reg = <0x54>; /* & 0x5c */
-		u-boot,dm-pre-reloc;
+		bootph-all;
 	};
 };
 

--- a/device_tree/data/kernel_dtsi/2024.1/BOARD/zynqmp-sm-k26-reva.dtsi
+++ b/device_tree/data/kernel_dtsi/2024.1/BOARD/zynqmp-sm-k26-reva.dtsi
@@ -247,20 +247,20 @@
 };
 
 &i2c1 {
-	u-boot,dm-pre-reloc;
+	bootph-all;
 	clock-frequency = <400000>;
 	scl-gpios = <&gpio 24 GPIO_ACTIVE_HIGH>;
 	sda-gpios = <&gpio 25 GPIO_ACTIVE_HIGH>;
 
 	eeprom: eeprom@50 { /* u46 - also at address 0x58 */
-		u-boot,dm-pre-reloc;
+		bootph-all;
 		compatible = "st,24c64", "atmel,24c64"; /* st m24c64 */
 		reg = <0x50>;
 		/* WP pin EE_WP_EN connected to slg7x644092@68 */
 	};
 
 	eeprom_cc: eeprom@51 { /* required by spec - also at address 0x59 */
-		u-boot,dm-pre-reloc;
+		bootph-all;
 		compatible = "st,24c64", "atmel,24c64"; /* st m24c64 */
 		reg = <0x51>;
 	};

--- a/device_tree/data/kernel_dtsi/2024.1/BOARD/zynqmp-vp-x-a2785-00-reva.dtsi
+++ b/device_tree/data/kernel_dtsi/2024.1/BOARD/zynqmp-vp-x-a2785-00-reva.dtsi
@@ -100,7 +100,7 @@
 };
 
 &uart0 { /* uart0 MIO38-39 */
-	u-boot,dm-pre-reloc;
+	bootph-all;
 };
 
 &gem0 {

--- a/device_tree/data/kernel_dtsi/2024.1/BOARD/zynqmp-vpk120-reva.dtsi
+++ b/device_tree/data/kernel_dtsi/2024.1/BOARD/zynqmp-vpk120-reva.dtsi
@@ -131,7 +131,7 @@
 };
 
 &uart0 { /* uart0 MIO38-39 */
-	u-boot,dm-pre-reloc;
+	bootph-all;
 };
 
 &gem0 {

--- a/device_tree/data/kernel_dtsi/2024.1/versal-net/versal-net-clk-ccf.dtsi
+++ b/device_tree/data/kernel_dtsi/2024.1/versal-net/versal-net-clk-ccf.dtsi
@@ -14,7 +14,7 @@
 
 / {
 	ref_clk: ref_clk {
-		u-boot,dm-pre-reloc;
+		bootph-all;
 		compatible = "fixed-clock";
 		#clock-cells = <0>;
 		clock-frequency = <33333333>;
@@ -39,7 +39,7 @@
 	firmware {
 		versal_net_firmware: versal-net-firmware {
 			compatible = "xlnx,versal-net-firmware", "xlnx,versal-firmware";
-			u-boot,dm-pre-reloc;
+			bootph-all;
 			method = "smc";
 			#power-domain-cells = <1>;
 
@@ -49,7 +49,7 @@
 			};
 
 			versal_net_clk: clock-controller {
-				u-boot,dm-pre-reloc;
+				bootph-all;
 				#clock-cells = <1>;
 				compatible = "xlnx,versal-net-clk", "xlnx,versal-clk";
 				clocks = <&ref_clk>, <&ref_clk>;

--- a/device_tree/data/kernel_dtsi/2024.1/versal-net/versal-net-clk.dtsi
+++ b/device_tree/data/kernel_dtsi/2024.1/versal-net/versal-net-clk.dtsi
@@ -73,7 +73,7 @@
 	firmware {
 		versal_net_firmware: versal-net-firmware {
 			compatible = "xlnx,versal-net-firmware", "xlnx,versal-firmware";
-			u-boot,dm-pre-reloc;
+			bootph-all;
 			method = "smc";
 
 			versal_net_reset: reset-controller {

--- a/device_tree/data/kernel_dtsi/2024.1/versal-net/versal-net-ipp-rev1.9.dtsi
+++ b/device_tree/data/kernel_dtsi/2024.1/versal-net/versal-net-ipp-rev1.9.dtsi
@@ -128,7 +128,7 @@
 
 	ref_clk: ref_clk {
 		compatible = "fixed-clock";
-		u-boot,dm-pre-reloc;
+		bootph-all;
 		#clock-cells = <0>;
 		clock-frequency = <33333333>;
 	};
@@ -137,12 +137,12 @@
 		versal_net_firmware: versal-net-firmware {
 			compatible = "xlnx,versal-net-firmware", "xlnx,versal-firmware";
 			interrupt-parent = <&gic>;
-			u-boot,dm-pre-reloc;
+			bootph-all;
 			method = "smc";
 			#power-domain-cells = <0x01>;
 
 			versal_net_clk: clock-controller {
-				u-boot,dm-pre-reloc;
+				bootph-all;
 				#clock-cells = <1>;
 				compatible = "xlnx,versal-net-clk", "xlnx,versal-clk";
 				clocks = <&ref_clk>, <&ref_clk>;
@@ -196,7 +196,7 @@
 
 	amba: axi {
 		compatible = "simple-bus";
-		u-boot,dm-pre-reloc;
+		bootph-all;
 		#address-cells = <2>;
 		#size-cells = <2>;
 		ranges;
@@ -548,7 +548,7 @@
 		};
 
 		serial0: serial@f1920000 {
-			u-boot,dm-pre-reloc;
+			bootph-all;
 			compatible = "arm,pl011", "arm,primecell";
 			reg = <0 0xf1920000 0 0x1000>;
 			interrupts = <0 25 4>;
@@ -562,7 +562,7 @@
 		};
 
 		serial1: serial@f1930000 {
-			u-boot,dm-pre-reloc;
+			bootph-all;
 			compatible = "arm,pl011", "arm,primecell";
 			reg = <0 0xf1930000 0 0x1000>;
 			interrupts = <0 26 4>;

--- a/device_tree/data/kernel_dtsi/2024.1/versal-net/versal-net.dtsi
+++ b/device_tree/data/kernel_dtsi/2024.1/versal-net/versal-net.dtsi
@@ -372,7 +372,7 @@
 	dcc: dcc {
 		compatible = "arm,dcc";
 		status = "disabled";
-		u-boot,dm-pre-reloc;
+		bootph-all;
 	};
 
 	firmware {
@@ -404,7 +404,7 @@
 		#size-cells = <2>;
 		ranges;
 		interrupt-parent = <&gic_a78>;
-		u-boot,dm-pre-reloc;
+		bootph-all;
 
 		gic_a78: interrupt-controller@e2000000 {
 			compatible = "arm,gic-v3";
@@ -433,7 +433,7 @@
 		#size-cells = <0x2>;
 		ranges;
 		interrupt-parent = <&gic_r52>;
-		u-boot,dm-pre-reloc;
+		bootph-all;
 
 		gic_r52: interrupt-controller@e2000000 {
 			compatible = "arm,gic-v3";
@@ -445,7 +445,7 @@
 
 	amba: axi {
 		compatible = "simple-bus";
-		u-boot,dm-pre-reloc;
+		bootph-all;
 		#address-cells = <2>;
 		#size-cells = <2>;
 		ranges;
@@ -1077,7 +1077,7 @@
 		};
 
 		serial0: serial@f1920000 {
-			u-boot,dm-pre-reloc;
+			bootph-all;
 			compatible = "arm,pl011", "arm,primecell";
 			status = "disabled";
 			reg = <0 0xf1920000 0 0x1000>;
@@ -1089,7 +1089,7 @@
 		};
 
 		serial1: serial@f1930000 {
-			u-boot,dm-pre-reloc;
+			bootph-all;
 			compatible = "arm,pl011", "arm,primecell";
 			status = "disabled";
 			reg = <0 0xf1930000 0 0x1000>;

--- a/device_tree/data/kernel_dtsi/2024.1/versal/versal-clk.dtsi
+++ b/device_tree/data/kernel_dtsi/2024.1/versal/versal-clk.dtsi
@@ -13,14 +13,14 @@
 #include "include/dt-bindings/reset/xlnx-versal-resets.h"
 / {
 	pl_alt_ref_clk: pl_alt_ref_clk {
-		u-boot,dm-pre-reloc;
+		bootph-all;
 		compatible = "fixed-clock";
 		#clock-cells = <0>;
 		clock-frequency = <33333333>;
 	};
 
 	ref_clk: ref_clk {
-		u-boot,dm-pre-reloc;
+		bootph-all;
 		compatible = "fixed-clock";
 		#clock-cells = <0>;
 		clock-frequency = <33333333>;
@@ -46,12 +46,12 @@
 		versal_firmware: versal-firmware {
 			compatible = "xlnx,versal-firmware";
 			interrupt-parent = <&imux>;
-			u-boot,dm-pre-reloc;
+			bootph-all;
 			method = "smc";
 			#power-domain-cells = <1>;
 
 			versal_clk: clock-controller {
-				u-boot,dm-pre-reloc;
+				bootph-all;
 				#clock-cells = <1>;
 				compatible = "xlnx,versal-clk";
 				clocks = <&ref_clk>, <&pl_alt_ref_clk>;

--- a/device_tree/data/kernel_dtsi/2024.1/versal/versal-spp-pm.dtsi
+++ b/device_tree/data/kernel_dtsi/2024.1/versal/versal-spp-pm.dtsi
@@ -10,21 +10,21 @@
 
 / {
 	alt_ref_clk: alt_ref_clk {
-		u-boot,dm-pre-reloc;
+		bootph-all;
 		compatible = "fixed-clock";
 		#clock-cells = <0>;
 		clock-frequency = <33333333>;
 	};
 
 	pl_alt_ref_clk: pl_alt_ref_clk {
-		u-boot,dm-pre-reloc;
+		bootph-all;
 		compatible = "fixed-clock";
 		#clock-cells = <0>;
 		clock-frequency = <33333333>;
 	};
 
 	ref_clk: ref_clk {
-		u-boot,dm-pre-reloc;
+		bootph-all;
 		compatible = "fixed-clock";
 		#clock-cells = <0>;
 		clock-frequency = <33333333>;
@@ -33,12 +33,12 @@
 	firmware {
 		versal_firmware: versal-firmware {
 			compatible = "xlnx,versal-firmware-wip";
-			u-boot,dm-pre-reloc;
+			bootph-all;
 			method = "smc";
 			#power-domain-cells = <1>;
 
 			versal_clk: clock-controller {
-				u-boot,dm-pre-reloc;
+				bootph-all;
 				#clock-cells = <1>;
 				compatible = "xlnx,versal-clk";
 				clocks = <&ref_clk>, <&alt_ref_clk>, <&pl_alt_ref_clk>;

--- a/device_tree/data/kernel_dtsi/2024.1/versal/versal.dtsi
+++ b/device_tree/data/kernel_dtsi/2024.1/versal/versal.dtsi
@@ -137,7 +137,7 @@
 	dcc: dcc {
 		compatible = "arm,dcc";
 		status = "disabled";
-		u-boot,dm-pre-reloc;
+		bootph-all;
 	};
 
 	fpga: fpga {
@@ -177,7 +177,7 @@
 		#size-cells = <2>;
 		ranges;
 		interrupt-parent = <&gic_a72>;
-		u-boot,dm-pre-reloc;
+		bootph-all;
 
 		gic_a72: interrupt-controller@f9000000 {
 			compatible = "arm,gic-v3";
@@ -208,7 +208,7 @@
 		#size-cells = <0x2>;
 		ranges;
 		interrupt-parent = <&gic_r5>;
-		u-boot,dm-pre-reloc;
+		bootph-all;
 
 		gic_r5: interrupt-controller@f9000000 {
 			compatible = "arm,pl390";
@@ -225,7 +225,7 @@
 		#size-cells = <2>;
 		ranges;
 		interrupt-parent = <&imux>;
-		u-boot,dm-pre-reloc;
+		bootph-all;
 
 		/* Proxy Interrupt Controller */
 		imux: interrupt-multiplex {
@@ -657,7 +657,7 @@
 			reg-io-width = <4>;
 			clock-names = "uartclk", "apb_pclk";
 			current-speed = <115200>;
-			u-boot,dm-pre-reloc;
+			bootph-all;
 		};
 
 		serial1: serial@ff010000 {
@@ -669,7 +669,7 @@
 			reg-io-width = <4>;
 			clock-names = "uartclk", "apb_pclk";
 			current-speed = <115200>;
-			u-boot,dm-pre-reloc;
+			bootph-all;
 		};
 
 		smmu: smmu@fd800000 {

--- a/device_tree/data/kernel_dtsi/2024.1/zynq/zynq-7000.dtsi
+++ b/device_tree/data/kernel_dtsi/2024.1/zynq/zynq-7000.dtsi
@@ -109,7 +109,7 @@
 	};
 
 	amba: axi {
-		u-boot,dm-pre-reloc;
+		bootph-all;
 		compatible = "simple-bus";
 		#address-cells = <1>;
 		#size-cells = <1>;
@@ -342,14 +342,14 @@
 		};
 
 		slcr: slcr@f8000000 {
-			u-boot,dm-pre-reloc;
+			bootph-all;
 			#address-cells = <1>;
 			#size-cells = <1>;
 			compatible = "xlnx,zynq-slcr", "syscon", "simple-mfd";
 			reg = <0xF8000000 0x1000>;
 			ranges;
 			clkc: clkc@100 {
-				u-boot,dm-pre-reloc;
+				bootph-all;
 				#clock-cells = <1>;
 				compatible = "xlnx,ps7-clkc";
 				fclk-enable = <0xf>;
@@ -439,6 +439,7 @@
 		};
 
 		scutimer: timer@f8f00600 {
+			bootph-all;
 			interrupt-parent = <&intc>;
 			interrupts = <1 13 0x301>;
 			compatible = "arm,cortex-a9-twd-timer";

--- a/device_tree/data/kernel_dtsi/2024.1/zynqmp/zynqmp-clk-ccf.dtsi
+++ b/device_tree/data/kernel_dtsi/2024.1/zynqmp/zynqmp-clk-ccf.dtsi
@@ -35,35 +35,35 @@
 	};
 
 	pss_ref_clk: pss_ref_clk {
-		u-boot,dm-pre-reloc;
+		bootph-all;
 		compatible = "fixed-clock";
 		#clock-cells = <0>;
 		clock-frequency = <33333333>;
 	};
 
 	video_clk: video_clk {
-		u-boot,dm-pre-reloc;
+		bootph-all;
 		compatible = "fixed-clock";
 		#clock-cells = <0>;
 		clock-frequency = <27000000>;
 	};
 
 	pss_alt_ref_clk: pss_alt_ref_clk {
-		u-boot,dm-pre-reloc;
+		bootph-all;
 		compatible = "fixed-clock";
 		#clock-cells = <0>;
 		clock-frequency = <0>;
 	};
 
 	gt_crx_ref_clk: gt_crx_ref_clk {
-		u-boot,dm-pre-reloc;
+		bootph-all;
 		compatible = "fixed-clock";
 		#clock-cells = <0>;
 		clock-frequency = <108000000>;
 	};
 
 	aux_ref_clk: aux_ref_clk {
-		u-boot,dm-pre-reloc;
+		bootph-all;
 		compatible = "fixed-clock";
 		#clock-cells = <0>;
 		clock-frequency = <27000000>;
@@ -72,7 +72,7 @@
 
 &zynqmp_firmware {
 	zynqmp_clk: clock-controller {
-		u-boot,dm-pre-reloc;
+		bootph-all;
 		#clock-cells = <1>;
 		compatible = "xlnx,zynqmp-clk";
 		clocks = <&pss_ref_clk>, <&video_clk>, <&pss_alt_ref_clk>,

--- a/device_tree/data/kernel_dtsi/2024.1/zynqmp/zynqmp.dtsi
+++ b/device_tree/data/kernel_dtsi/2024.1/zynqmp/zynqmp.dtsi
@@ -152,7 +152,7 @@
 	};
 
 	zynqmp_ipi: zynqmp-ipi {
-		u-boot,dm-pre-reloc;
+		bootph-all;
 		compatible = "xlnx,zynqmp-ipi-mailbox";
 		interrupt-parent = <&imux>;
 		interrupts = <0 35 4>;
@@ -162,7 +162,7 @@
 		ranges;
 
 		ipi_mailbox_pmu1: mailbox@ff9905c0 {
-			u-boot,dm-pre-reloc;
+			bootph-all;
 			reg = <0x0 0xff9905c0 0x0 0x20>,
 			      <0x0 0xff9905e0 0x0 0x20>,
 			      <0x0 0xff990e80 0x0 0x20>,
@@ -179,7 +179,7 @@
 	dcc: dcc {
 		compatible = "arm,dcc";
 		status = "disabled";
-		u-boot,dm-pre-reloc;
+		bootph-all;
 	};
 
 	pmu {
@@ -203,12 +203,12 @@
 	firmware {
 		zynqmp_firmware: zynqmp-firmware {
 			compatible = "xlnx,zynqmp-firmware";
-			u-boot,dm-pre-reloc;
+			bootph-all;
 			method = "smc";
 			#power-domain-cells = <0x1>;
 
 			zynqmp_power: zynqmp-power {
-				u-boot,dm-pre-reloc;
+				bootph-all;
 				compatible = "xlnx,zynqmp-power";
 				interrupt-parent = <&imux>;
 				interrupts = <0 35 4>;
@@ -362,7 +362,7 @@
 
 	amba: axi {
 		compatible = "simple-bus";
-		u-boot,dm-pre-reloc;
+		bootph-all;
 		#address-cells = <2>;
 		#size-cells = <2>;
 		ranges;
@@ -1035,7 +1035,7 @@
 		};
 
 		qspi: spi@ff0f0000 {
-			u-boot,dm-pre-reloc;
+			bootph-all;
 			compatible = "xlnx,zynqmp-qspi-1.0";
 			status = "disabled";
 			clock-names = "ref_clk", "pclk";
@@ -1082,7 +1082,7 @@
 		};
 
 		sdhci0: mmc@ff160000 {
-			u-boot,dm-pre-reloc;
+			bootph-all;
 			compatible = "xlnx,zynqmp-8.9a", "arasan,sdhci-8.9a";
 			status = "disabled";
 			interrupt-parent = <&imux>;
@@ -1097,7 +1097,7 @@
 		};
 
 		sdhci1: mmc@ff170000 {
-			u-boot,dm-pre-reloc;
+			bootph-all;
 			compatible = "xlnx,zynqmp-8.9a", "arasan,sdhci-8.9a";
 			status = "disabled";
 			interrupt-parent = <&imux>;
@@ -1190,7 +1190,7 @@
 		};
 
 		uart0: serial@ff000000 {
-			u-boot,dm-pre-reloc;
+			bootph-all;
 			compatible = "xlnx,zynqmp-uart", "cdns,uart-r1p12";
 			status = "disabled";
 			interrupt-parent = <&imux>;
@@ -1201,7 +1201,7 @@
 		};
 
 		uart1: serial@ff010000 {
-			u-boot,dm-pre-reloc;
+			bootph-all;
 			compatible = "xlnx,zynqmp-uart", "cdns,uart-r1p12";
 			status = "disabled";
 			interrupt-parent = <&imux>;
@@ -1335,7 +1335,7 @@
 		};
 
 		zynqmp_dpsub: display@fd4a0000 {
-			u-boot,dm-pre-reloc;
+			bootph-all;
 			compatible = "xlnx,zynqmp-dpsub-1.7";
 			status = "disabled";
 			reg = <0x0 0xfd4a0000 0x0 0x1000>,
@@ -1421,7 +1421,7 @@
 			xlnx,ipi-buf-index = <2>;
 			#address-cells = <2>;
 			#size-cells = <2>;
-			u-boot,dm-pre-reloc;
+			bootph-all;
 			ranges;
 		};
 
@@ -1436,7 +1436,7 @@
 			xlnx,ipi-buf-index = <0>;
 			#address-cells = <2>;
 			#size-cells = <2>;
-			u-boot,dm-pre-reloc;
+			bootph-all;
 			ranges;
 		};
 
@@ -1451,7 +1451,7 @@
 			xlnx,ipi-buf-index = <1>;
 			#address-cells = <2>;
 			#size-cells = <2>;
-			u-boot,dm-pre-reloc;
+			bootph-all;
 			ranges;
 		};
 
@@ -1464,7 +1464,7 @@
 			xlnx,ipi-buf-index = <7>;
 			#address-cells = <2>;
 			#size-cells = <2>;
-			u-boot,dm-pre-reloc;
+			bootph-all;
 			ranges;
 		};
 
@@ -1477,7 +1477,7 @@
 			xlnx,ipi-buf-index = <7>;
 			#address-cells = <2>;
 			#size-cells = <2>;
-			u-boot,dm-pre-reloc;
+			bootph-all;
 			ranges;
 		};
 
@@ -1490,7 +1490,7 @@
 			xlnx,ipi-buf-index = <7>;
 			#address-cells = <2>;
 			#size-cells = <2>;
-			u-boot,dm-pre-reloc;
+			bootph-all;
 			ranges;
 		};
 
@@ -1503,7 +1503,7 @@
 			xlnx,ipi-buf-index = <7>;
 			#address-cells = <2>;
 			#size-cells = <2>;
-			u-boot,dm-pre-reloc;
+			bootph-all;
 			ranges;
 		};
 
@@ -1518,7 +1518,7 @@
 			xlnx,ipi-buf-index = <3>;
 			#address-cells = <2>;
 			#size-cells = <2>;
-			u-boot,dm-pre-reloc;
+			bootph-all;
 			ranges;
 		};
 
@@ -1533,7 +1533,7 @@
 			xlnx,ipi-buf-index = <4>;
 			#address-cells = <2>;
 			#size-cells = <2>;
-			u-boot,dm-pre-reloc;
+			bootph-all;
 			ranges;
 
 		};
@@ -1549,7 +1549,7 @@
 			xlnx,ipi-buf-index = <5>;
 			#address-cells = <2>;
 			#size-cells = <2>;
-			u-boot,dm-pre-reloc;
+			bootph-all;
 			ranges;
 
 		};
@@ -1565,7 +1565,7 @@
 			xlnx,ipi-buf-index = <5>;
 			#address-cells = <2>;
 			#size-cells = <2>;
-			u-boot,dm-pre-reloc;
+			bootph-all;
 			ranges;
 
 		};

--- a/dfeccf/data/dfeccf.tcl
+++ b/dfeccf/data/dfeccf.tcl
@@ -1,0 +1,29 @@
+#
+# (C) Copyright 2024 Advanced Micro Devices, Inc. All Rights Reserved.
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License as
+# published by the Free Software Foundation; either version 2 of
+# the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+# GNU General Public License for more details.
+#
+
+proc dfeccf_generate {drv_handle} {
+	set node [get_node $drv_handle]
+	set dts_file [set_drv_def_dts $drv_handle]
+	set count 0
+	foreach handle [hsi::get_cells -hier] {
+		set ip_name [hsi get_property IP_NAME $handle]
+		if {[string match -nocase $ip_name "xdfe_cc_filter"] } {
+			set count [expr $count + 1]
+		}
+	}
+	add_prop $node "num-insts" $count hexlist $dts_file
+
+	set value [hsi get_property "CONFIG.C_SWITCHABLE" $drv_handle]
+	add_prop $node "xlnx,switchable" $value string $dts_file 1
+}

--- a/intc/data/intc.tcl
+++ b/intc/data/intc.tcl
@@ -27,6 +27,7 @@
         set zocl [get_user_config $common_file -dt_zocl]
         pldt append $node compatible "\ \, \"xlnx,xps-intc-1.00.a\""
         add_prop $node "#interrupt-cells" 2 int "pl.dtsi"
+        add_prop $node "#address-cells" 2 int "pl.dtsi"
         add_prop $node "interrupt-controller" boolean "pl.dtsi"
         set ip [hsi::get_cells -hier $drv_handle]
         set num_intr_inputs [get_ip_param_value $ip C_NUM_INTR_INPUTS]
@@ -49,7 +50,7 @@
         add_prop $node "xlnx,kind-of-intr" $kind_of_intr hexint $dts_file 1
         if {$zocl} {
                 set num_intr_inputs "0x20"
-                set_drv_prop $drv_handle "xlnx,num-intr-inputs" $num_intr_inputs $node int
+                set_drv_prop_if_empty $drv_handle "xlnx,num-intr-inputs" $num_intr_inputs $node int
         } else {
                 set_drv_conf_prop $drv_handle C_NUM_INTR_INPUTS "xlnx,num-intr-inputs" $node
         }

--- a/mig_7series/data/mig_7series.tcl
+++ b/mig_7series/data/mig_7series.tcl
@@ -15,6 +15,7 @@
 
 proc mig_7series_generate {drv_handle} {
         global apu_proc_ip
+        global is_64_bit_mb
         set apu_proc_found 0
         set 64_bit 0
         set baseaddr [get_baseaddr $drv_handle no_prefix]
@@ -54,7 +55,7 @@ proc mig_7series_generate {drv_handle} {
                                 set size [format 0x%x [expr {${high} - ${base}}]]
                         }
 
-                        if {[is_zynqmp_platform $proctype] || [string match -nocase $proctype "versal"]  || [string length [string trimleft $base "0x"]] > 8} {
+                        if {[is_zynqmp_platform $proctype] || [string match -nocase $proctype "versal"]  || [string length [string trimleft $base "0x"]] > 8 || $is_64_bit_mb} {
                                 set 64_bit 1
                                 if {[regexp -nocase {0x([0-9a-f]{9})} "$base" match]} {
                                         set temp $base

--- a/mipi_dsi2_rx/data/mipi_dsi2_rx.tcl
+++ b/mipi_dsi2_rx/data/mipi_dsi2_rx.tcl
@@ -1,0 +1,36 @@
+#
+# (C) Copyright 2024 Advanced Micro Devices, Inc. All Rights Reserved.
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License as
+# published by the Free Software Foundation; either version 2 of
+# the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+# GNU General Public License for more details.
+#
+
+    proc mipi_dsi2_rx_generate {drv_handle} {
+        set node [get_node $drv_handle]
+        set dts_file [set_drv_def_dts $drv_handle]
+        if {$node == 0} {
+                return
+        }
+        pldt append $node compatible "\ \, \"xlnx,dsi\""
+        set dsi_num_lanes [hsi get_property CONFIG.DSI_LANES [hsi::get_cells -hier $drv_handle]]
+        add_prop "$node" "xlnx,dsi-num-lanes" $dsi_num_lanes int $dts_file
+        set dsi_pixels_perbeat [hsi get_property CONFIG.DSI_PIXELS [hsi::get_cells -hier $drv_handle]]
+        add_prop "$node" "xlnx,dsi-pixels-perbeat" $dsi_pixels_perbeat int $dts_file
+        set dsi_datatype [hsi get_property CONFIG.DSI_DATATYPE [hsi::get_cells -hier $drv_handle]]
+        if {[string match -nocase $dsi_datatype "RGB888"]} {
+                add_prop "$node" "xlnx,dsi-data-type" 0 int $dts_file
+        } elseif {[string match -nocase $dsi_datatype "RGB666_L"]} {
+                add_prop "$node" "xlnx,dsi-data-type" 1 int $dts_file
+        } elseif {[string match -nocase $dsi_datatype "RGB666_P"]} {
+                add_prop "$node" "xlnx,dsi-data-type" 2 int $dts_file
+        } elseif {[string match -nocase $dsi_datatype "RGB565"]} {
+                add_prop "$node" "xlnx,dsi-data-type" 3 int $dts_file
+        }
+    }

--- a/mipi_dsi2_rx_core/data/mipi_dsi2_rx_core.tcl
+++ b/mipi_dsi2_rx_core/data/mipi_dsi2_rx_core.tcl
@@ -1,0 +1,23 @@
+#
+# (C) Copyright 2024 Advanced Micro Devices, Inc. All Rights Reserved.
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License as
+# published by the Free Software Foundation; either version 2 of
+# the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+# GNU General Public License for more details.
+#
+
+    proc mipi_dsi2_rx_core_generate {drv_handle} {
+
+	set node [get_node $drv_handle]
+        set dts_file [set_drv_def_dts $drv_handle]
+        if {$node == 0} {
+                return
+        }
+
+}

--- a/mipi_dsi2_rx_ss/data/mipi_dsi2_rx_ss.tcl
+++ b/mipi_dsi2_rx_ss/data/mipi_dsi2_rx_ss.tcl
@@ -1,0 +1,94 @@
+#
+# (C) Copyright 2024 Advanced Micro Devices, Inc. All Rights Reserved.
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License as
+# published by the Free Software Foundation; either version 2 of
+# the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+# GNU General Public License for more details.
+#
+
+    proc mipi_dsi2_rx_ss_generate {drv_handle} {
+        set node [get_node $drv_handle]
+        set dts_file [set_drv_def_dts $drv_handle]
+        if {$node == 0} {
+                return
+        }
+
+	set dphy_en_reg_if [hsi get_property CONFIG.DPHY_EN_REG_IF [hsi::get_cells -hier $drv_handle]]
+        if  {[string match -nocase "true" $dphy_en_reg_if]} {
+                add_prop "${node}" "xlnx,dphy-en-reg-if" 1 int $dts_file 1
+        } elseif {[string match -nocase "false" $dphy_en_reg_if]} {
+                add_prop "${node}" "xlnx,dphy-en-reg-if" 0 int $dts_file 1
+	}
+	set dphymode [hsi get_property CONFIG.C_DPHY_MODE [hsi::get_cells -hier $drv_handle]]
+        if  {[string match -nocase "master" $dphymode]} {
+                add_prop "${node}" "xlnx,dphy-mode" 1 int $dts_file 1
+        } elseif {[string match -nocase "slave" $dphymode]} {
+                add_prop "${node}" "xlnx,dphy-mode" 0 int $dts_file 1
+	}
+
+        set dsi_datatype [hsi get_property CONFIG.DSI_DATATYPE [hsi::get_cells -hier $drv_handle]]
+	set pixel [pixel_format $dsi_datatype]
+        add_prop "$node" "xlnx,dsi-datatype" $pixel hexint $dts_file 1
+
+	set highaddr [hsi get_property CONFIG.C_HIGHADDR  [hsi get_cells -hier $drv_handle]]
+	add_prop "${node}" "xlnx,highaddr" $highaddr hexint $dts_file 1
+
+	dsi2rx_add_hier_instances $drv_handle
+
+    }
+
+proc dsi2rx_add_hier_instances {drv_handle} {
+	set node [get_node $drv_handle]
+	set subsystem_base_addr [get_baseaddr $drv_handle]
+	set dts_file [set_drv_def_dts $drv_handle]
+	hsi::current_hw_instance $drv_handle
+
+	#Example :
+	#hsi::get_cells -hier -filter {IP_NAME==mipi_dsi2_rx_ctrl}
+	#dsirx_0_rx
+	#
+
+	set ip_subcores [dict create]
+	dict set ip_subcores "mipi_dsi2_rx_ctrl" "dsi-rx"
+	dict set ip_subcores "mipi_dphy" "dphy"
+
+	foreach ip [dict keys $ip_subcores] {
+		set ip_handle [hsi::get_cells -hier -filter "IP_NAME==$ip"]
+		set ip_prefix [dict get $ip_subcores $ip]
+		if {![string_is_empty $ip_handle]} {
+			add_prop "$node" "${ip_prefix}-present" 1 int $dts_file
+			add_prop "$node" "${ip_prefix}-connected" $ip_handle reference $dts_file
+		} else {
+			add_prop "$node" "${ip_prefix}-present" 0 int $dts_file
+		}
+	}
+
+	hsi::current_hw_instance
+}
+proc pixel_format {pxl_format} {
+	set pixel_format ""
+            switch $pxl_format {
+                   "RGB565" {
+                           set pixel_format 0x0E
+                   }
+                   "RGB666_P" {
+                           set pixel_format 0x1E
+                   }
+                   "RGB666_L" {
+                           set pixel_format 0x2E
+                   }
+                   "RGB888" {
+                           set pixel_format 0x3E
+                   }
+                   "Compressed" {
+                           set pixel_format 0x0B
+                   }
+            }
+	return $pixel_format
+}

--- a/pmups/data/pmups.tcl
+++ b/pmups/data/pmups.tcl
@@ -1,6 +1,6 @@
 #
 # (C) Copyright 2014-2022 Xilinx, Inc.
-# (C) Copyright 2022-2023 Advanced Micro Devices, Inc. All Rights Reserved.
+# (C) Copyright 2022-2024 Advanced Micro Devices, Inc. All Rights Reserved.
 #
 # This program is free software; you can redistribute it and/or
 # modify it under the terms of the GNU General Public License as
@@ -16,21 +16,22 @@
     proc pmups_generate {drv_handle} {
         set ip_name [get_ip_property $drv_handle IP_NAME]
         if {[string match -nocase $ip_name "psu_pmu"]} {
-                set node [pcwdt insert root end "&psu_pmu_0"]
+                set node [create_node -n "&psu_pmu_0" -d "pcw.dtsi" -p root -h $drv_handle]
                 add_prop $node "clock-frequency" [hsi get_property CONFIG.C_FREQ $drv_handle] hexint "pcw.dtsi"
                 add_prop $node "microblaze_ddr_reserve_ea" [hsi get_property CONFIG.C_DDR_RESERVE_EA $drv_handle] int "pcw.dtsi"
                 add_prop $node "microblaze_ddr_reserve_sa" [hsi get_property CONFIG.C_DDR_RESERVE_SA $drv_handle] int "pcw.dtsi"
                 gen_pss_ref_clk_freq $drv_handle $node $ip_name
         } elseif {[string match -nocase $ip_name "psv_pmc"]} {
-                set node [pcwdt insert root end "&psv_pmc_0"]
+                set node [create_node -n "&psv_pmc_0" -d "pcw.dtsi" -p root -h $drv_handle]
                 gen_pss_ref_clk_freq $drv_handle $node $ip_name
         } elseif {[string match -nocase $ip_name "psv_psm"]} {
-                set node [pcwdt insert root end "&psv_psm_0"]
+                set node [create_node -n "&psv_psm_0" -d "pcw.dtsi" -p root -h $drv_handle]
         } elseif {[string match -nocase $ip_name "psx_pmc"]} {
-                set node [pcwdt insert root end "&psx_pmc_0"]
+                set node [create_node -n "&psx_pmc_0" -d "pcw.dtsi" -p root -h $drv_handle]
                 gen_pss_ref_clk_freq $drv_handle $node $ip_name
         } elseif {[string match -nocase $ip_name "psx_psm"]} {
-                set node [pcwdt insert root end "&psx_psm_0"]
+                set node [create_node -n "&psx_psm_0" -d "pcw.dtsi" -p root -h $drv_handle]
+
         } else {
                 error "Driver pmups is not valid for given handle $drv_handle"
         }

--- a/uartns/data/uartns.tcl
+++ b/uartns/data/uartns.tcl
@@ -24,21 +24,15 @@
         set ip [hsi::get_cells -hier $drv_handle]
         set has_xin [get_ip_param_value $ip C_HAS_EXTERNAL_XIN]
         set clock_port "S_AXI_ACLK"
-        if { [string match -nocase "$has_xin" "1"] } {
-        set_drv_conf_prop $drv_handle C_EXTERNAL_XIN_CLK_HZ clock-frequency $node
-        # TODO: update the clock-names and clocks properties and create a
-        # fixed clock node. Currently this is causing any issue as the
-        # driver only uses clock-frequency property
 
-        } else {
         set freq [get_clk_pin_freq $ip "$clock_port"]
         add_prop $node "xlnx,clock-freq" $freq int $dts_file
-        }
 
         set proctype [get_hw_family]
         if {[regexp "microblaze" $proctype match]} {
                  gen_dev_ccf_binding $drv_handle "s_axi_aclk"
         }
+        pldt unset $node "clock-frequency"
     }
 
 


### PR DESCRIPTION
## 📋 Fix issues with device tree overlay generation for interrupt controller.

### 📌 Description

Fixes the device tree overlay generation issues in the interrupt controller

- **Type of Change**: Bugfix

### 🚀 What Has Been Done?
- [x] In the file `common_proc.tcl` a semi-collon was mission in the device tree version marker 
- [x] In the in file `intc/data/intc.tcl` the argument order for the `set_drv_prop` function is not correct.

### 🧪 Testing 

I just executed the generation for the device tree I needed. I could not find the tests in this repo. If they exist I can run them.

I used the following configuration

```yaml
---
dict_devicetree:
    kernel_ver: 2024.1
    mainline_kernel: none 
    board_dts: zynqmp-smk-k26-reva
    dt_overlay: true
    output_dir: build
    dt_zocl: true
---

```

There where two errors generated:

1. for the device tree version marker

  ```
  pl.dtsi:2.1-9 syntax error
  FATAL ERROR: Unable to parse input tree
  ```
2. another one for the interrupt controller

```
pl.dtsi:40.33-34 syntax error
FATAL ERROR: Unable to parse input tree
```

line 40 contains the following.

```
xlnx,num-intr-inputs = <32> <0x20>;
```