### PR TITLE
debug_bridge.tcl: Fix compatible string of debug_bridge.

### DIFF
--- a/debug_bridge/data/debug_bridge.tcl
+++ b/debug_bridge/data/debug_bridge.tcl
@@ -18,7 +18,7 @@
         if {$node == 0} {
                 return
         }
-        pldt append $node compatible "\ \, \"generic-uio\""
+        pldt append $node compatible "\ \, \"xlnx,xvc\""
     }
 
 


### PR DESCRIPTION
The device tree node for the Xilinx Debug Bridge IP in the SDT generated device tree (pl.dtsi) does not match the compatibility string for the device driver.

ref: https://xilinx-wiki.atlassian.net/wiki/spaces/A/pages/644579329/Xilinx+Virtual+Cable#PetaLinux-Device-Tree