### PR TITLE
Add 16550 UART driver to compatible string

### DIFF
--- a/uartns/data/uartns.tcl
+++ b/uartns/data/uartns.tcl
@@ -34,6 +34,8 @@
         }
         pldt unset $node "clock-frequency"
         set keyval [pldt append $node compatible "\ \, \"xlnx,axi-uart16550\""]
+        set keyval [pldt append $node compatible "\ \, \"ns16550a\""]
+
     }
 
 


### PR DESCRIPTION
Lopper/SDTGen fails to load the driver for the AXI 16550 UART IP when loaded on the Kria KR260 starter kit using AMD-EDF 2025.2. The `compatible` string does not match anything in linux-xlnx/drivers/tty/serial/8250/8250_of.c.

This PR adds the compatible string to match the behaviour of the XSCT device-tree generator and successfully loads the drivers.